### PR TITLE
docs: Update rules.md for v1.4.2 (#773)

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -259,14 +259,28 @@ output: "Attack (ip=%nginx.remote_addr% uri=%nginx.request_uri% ua=%nginx.http_u
 
 ### Advanced Examples
 
-#### Rate Limiting Detection
+#### Using Macros for Reusable Patterns
 ```yaml
-- rule: Potential DDoS Attack
-  desc: High request rate from single IP
-  condition: nginx.request_time < 0.01  # Very fast requests
-  output: "High request rate (ip=%nginx.remote_addr% time=%nginx.request_time%ms)"
-  priority: WARNING
-  tags: [ddos, rate_limit]
+# Define reusable macros
+- macro: sql_injection_patterns
+  condition: >
+    nginx.request_uri icontains "' OR" or
+    nginx.request_uri icontains "UNION SELECT" or
+    nginx.request_uri icontains "%27%20OR"
+
+- macro: xss_patterns
+  condition: >
+    nginx.request_uri icontains "<script" or
+    nginx.request_uri icontains "javascript:" or
+    nginx.request_uri icontains "%3Cscript"
+
+# Use macros in rules
+- rule: Web Attack Detected
+  desc: Detects SQL injection or XSS attacks
+  condition: sql_injection_patterns or xss_patterns
+  output: "Web attack detected (ip=%nginx.remote_addr uri=%nginx.request_uri)"
+  priority: CRITICAL
+  tags: [attack, web]
   source: nginx
 ```
 
@@ -627,14 +641,28 @@ output: "攻撃 (ip=%nginx.remote_addr uri=%nginx.request_uri ua=%nginx.user_age
 
 ### 高度な例
 
-#### レート制限検出
+#### 再利用可能なパターンのためのマクロ使用
 ```yaml
-- rule: Potential DDoS Attack
-  desc: 単一IPからの高リクエストレート
-  condition: nginx.request_time < 0.01  # 非常に高速なリクエスト
-  output: "高リクエストレート (ip=%nginx.remote_addr% time=%nginx.request_time%ms)"
-  priority: WARNING
-  tags: [ddos, rate_limit]
+# 再利用可能なマクロを定義
+- macro: sql_injection_patterns
+  condition: >
+    nginx.request_uri icontains "' OR" or
+    nginx.request_uri icontains "UNION SELECT" or
+    nginx.request_uri icontains "%27%20OR"
+
+- macro: xss_patterns
+  condition: >
+    nginx.request_uri icontains "<script" or
+    nginx.request_uri icontains "javascript:" or
+    nginx.request_uri icontains "%3Cscript"
+
+# ルールでマクロを使用
+- rule: Web Attack Detected
+  desc: SQLインジェクションまたはXSS攻撃を検出
+  condition: sql_injection_patterns or xss_patterns
+  output: "Web攻撃を検出 (ip=%nginx.remote_addr uri=%nginx.request_uri)"
+  priority: CRITICAL
+  tags: [attack, web]
   source: nginx
 ```
 


### PR DESCRIPTION
## Summary

Update `docs/rules.md` to match the actual plugin implementation (v1.4.2) and incorporate E2E-verified best practices.

### Changes

#### Field Updates
- **Fixed field names**: `nginx.http_referer` → `nginx.referer`, `nginx.http_user_agent` → `nginx.user_agent`
- **Removed non-existent fields**: `nginx.body_bytes_sent`, `nginx.request_length`, `nginx.request_time`, `nginx.upstream_response_time`
- **Added new fields**: `nginx.raw`, `nginx.headers[key]`

#### Operator Updates
- Added `icontains` operator documentation (case-insensitive, recommended for security patterns)
- Added notes about URL-encoded pattern detection (`%27`, `%3c`)

#### Rule Examples
- Updated SQL Injection example to use `icontains`
- Added HTTP Headers usage example (`nginx.headers[key]`)
- Fixed all examples to use correct field names

#### Priority Levels
- Fixed from 5 levels to 8 levels: EMERGENCY|ALERT|CRITICAL|ERROR|WARNING|NOTICE|INFO|DEBUG

#### New Section
- Added "Common Mistakes to Avoid" section with 5 common errors

#### Other
- Added version information (Version: 1.4.2 | Last Updated: 2025-12-06)
- Updated both English and Japanese sections

## References

- Requirements: `claudedocs/ISSUE_773_RULES_MD_UPDATE_REQUIREMENTS.md`
- Task Definition: `claudedocs/ISSUE_773_TASK_DEFINITION.md`
- Source of truth: `plugin/main.go` Fields() function

## Test Plan

- [ ] Verify field names match `plugin/main.go`
- [ ] Verify all rule examples are syntactically correct
- [ ] Verify English and Japanese sections are consistent

Fixes https://github.com/takaosgb3/falco-nginx-plugin-claude/issues/773

🤖 Generated with Claude Code