### PR TITLE
perf(e2e): Reduce BATCH_WAIT_TIME from 60s to 5s

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -53,8 +53,8 @@ env:
   # Falco configuration
   FALCO_LOG_PATH: /var/log/falco/falco.log
   NGINX_LOG_PATH: /var/log/nginx/access.log
-  # Batch processing
-  BATCH_WAIT_TIME: '60'
+  # Batch processing (Issue #8: reduced from 60s to 5s)
+  BATCH_WAIT_TIME: '5'
   # Detection threshold
   MIN_DETECTION_RATE: '0.95'
 


### PR DESCRIPTION
## Summary

- Reduce `BATCH_WAIT_TIME` from 60s to 5s
- Expected workflow time reduction: ~55 seconds

## Analysis

From Run #14 logs:
| Timestamp | Event |
|-----------|-------|
| 11:52:17 | k6 tests started |
| 11:52:39 | k6 tests completed (~22s) |
| 11:53:39 | After 60s wait: **130/130 detections already complete** |

Falco's nginx plugin processes logs in real-time. Detections are available immediately after k6 tests finish.

## Test Plan

- [ ] Verify detection rate remains 100% (65/65)
- [ ] Verify workflow completes successfully
- [ ] Compare execution time with previous runs

Fixes #8