### PR TITLE
fix(e2e): Add root index.html redirect to latest Allure report

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -575,6 +575,39 @@ jobs:
           keep_files: false
 
       # ========================================
+      # 14b. Create root index.html (Issue #10)
+      # ========================================
+      - name: Create root redirect
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        run: |
+          echo "Creating root redirect to latest E2E report"
+
+          mkdir -p root-redirect
+          cat > root-redirect/index.html << EOF
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <meta http-equiv="refresh" content="0; url=e2e-report/${{ github.run_number }}/" />
+            <title>Falco nginx Plugin - E2E Test Reports</title>
+          </head>
+          <body>
+            <h1>Falco nginx Plugin - E2E Test Reports</h1>
+            <p>Redirecting to <a href="e2e-report/${{ github.run_number }}/">latest report (Run #${{ github.run_number }})</a>...</p>
+            <p><a href="e2e-report/latest/">Latest Report</a></p>
+          </body>
+          </html>
+          EOF
+
+      - name: Deploy root redirect
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./root-redirect
+          destination_dir: .
+          keep_files: true
+
+      # ========================================
       # 15. Job Summary
       # ========================================
       - name: Generate Job Summary


### PR DESCRIPTION
## Summary

Add root index.html that redirects to the latest Allure report.

## Problem

When clicking the deploy URL in GitHub Actions (`https://takaosgb3.github.io/falco-plugin-nginx/`), users see a 404 error.

## Solution

Create an `index.html` at the root of GitHub Pages that redirects to the latest E2E report:

- `https://takaosgb3.github.io/falco-plugin-nginx/` → redirects to latest report
- `https://takaosgb3.github.io/falco-plugin-nginx/e2e-report/latest/` → also available

## Test Plan

1. Verify workflow completes successfully
2. Access https://takaosgb3.github.io/falco-plugin-nginx/
3. Confirm redirect to latest Allure report

Fixes #10