### PR TITLE
fix: Update expected_rule to match actual Falco rule names (Issue #12)

### DIFF
--- a/e2e/patterns/cmdinj_patterns.json
+++ b/e2e/patterns/cmdinj_patterns.json
@@ -16,7 +16,7 @@
       "port": 8004,
       "expected_detection": true,
       "severity": "critical",
-      "expected_rule": "Command Injection Attack",
+      "expected_rule": "Command Injection via Semicolon",
       "rule_id": "ADV_CMDI_001"
     },
     {
@@ -29,8 +29,8 @@
       "port": 8004,
       "expected_detection": true,
       "severity": "critical",
-      "expected_rule": "Command Injection Attack",
-      "rule_id": "ADV_CMDI_001"
+      "expected_rule": "Advanced Command Injection Attempt",
+      "rule_id": "ADV_CMDI_004"
     },
     {
       "id": "CMD_BASIC_003",
@@ -42,8 +42,8 @@
       "port": 8004,
       "expected_detection": true,
       "severity": "critical",
-      "expected_rule": "Command Injection Attack",
-      "rule_id": "ADV_CMDI_001"
+      "expected_rule": "Command Injection via Pipe",
+      "rule_id": "ADV_CMDI_002"
     },
     {
       "id": "CMD_BASIC_004",
@@ -55,8 +55,8 @@
       "port": 8004,
       "expected_detection": true,
       "severity": "critical",
-      "expected_rule": "Command Injection Attack",
-      "rule_id": "ADV_CMDI_001"
+      "expected_rule": "Advanced Command Injection Attempt",
+      "rule_id": "ADV_CMDI_004"
     },
     {
       "id": "CMD_BASIC_005",
@@ -68,7 +68,7 @@
       "port": 8004,
       "expected_detection": true,
       "severity": "critical",
-      "expected_rule": "Command Injection Attack",
+      "expected_rule": "Command Injection via Semicolon",
       "rule_id": "ADV_CMDI_001"
     },
     {
@@ -81,7 +81,7 @@
       "port": 8004,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Command Injection Attack",
+      "expected_rule": "Command Injection via Semicolon",
       "rule_id": "ADV_CMDI_001"
     },
     {
@@ -94,8 +94,8 @@
       "port": 8004,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Command Injection Attack",
-      "rule_id": "ADV_CMDI_001"
+      "expected_rule": "Advanced Command Injection Attempt",
+      "rule_id": "ADV_CMDI_004"
     },
     {
       "id": "CMD_BASIC_008",
@@ -107,8 +107,8 @@
       "port": 8004,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Command Injection Attack",
-      "rule_id": "ADV_CMDI_001"
+      "expected_rule": "Command Injection via Pipe",
+      "rule_id": "ADV_CMDI_002"
     },
     {
       "id": "CMD_BASIC_009",
@@ -120,7 +120,7 @@
       "port": 8004,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Command Injection Attack",
+      "expected_rule": "Command Injection via Semicolon",
       "rule_id": "ADV_CMDI_001"
     },
     {
@@ -133,8 +133,8 @@
       "port": 8004,
       "expected_detection": true,
       "severity": "medium",
-      "expected_rule": "Command Injection Attack",
-      "rule_id": "ADV_CMDI_001"
+      "expected_rule": "Advanced Command Injection Attempt",
+      "rule_id": "ADV_CMDI_004"
     }
   ]
 }

--- a/e2e/patterns/other_patterns.json
+++ b/e2e/patterns/other_patterns.json
@@ -16,7 +16,7 @@
       "port": 8005,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Emerging Threat: NoSQL/MongoDB Injection",
+      "expected_rule": "MongoDB NoSQL Injection Detection",
       "rule_id": "EMRG_NOSQL_001"
     },
     {
@@ -29,7 +29,7 @@
       "port": 8005,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Emerging Threat: NoSQL/MongoDB Injection",
+      "expected_rule": "MongoDB NoSQL Injection Detection",
       "rule_id": "EMRG_NOSQL_001"
     },
     {
@@ -42,7 +42,7 @@
       "port": 8005,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Emerging Threat: NoSQL/MongoDB Injection",
+      "expected_rule": "MongoDB NoSQL Injection Detection",
       "rule_id": "EMRG_NOSQL_001"
     },
     {
@@ -55,7 +55,7 @@
       "port": 8005,
       "expected_detection": true,
       "severity": "medium",
-      "expected_rule": "Emerging Threat: NoSQL/MongoDB Injection",
+      "expected_rule": "MongoDB NoSQL Injection Detection",
       "rule_id": "EMRG_NOSQL_001"
     },
     {
@@ -68,7 +68,7 @@
       "port": 8005,
       "expected_detection": true,
       "severity": "critical",
-      "expected_rule": "Emerging Threat: NoSQL/MongoDB Injection",
+      "expected_rule": "MongoDB NoSQL Injection Detection",
       "rule_id": "EMRG_NOSQL_001"
     }
   ]

--- a/e2e/patterns/path_patterns.json
+++ b/e2e/patterns/path_patterns.json
@@ -16,8 +16,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "Basic Path Traversal Attack",
+      "rule_id": "ADV_TRAV_001"
     },
     {
       "id": "PATH_BASIC_002",
@@ -29,8 +29,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "Basic Path Traversal Attack",
+      "rule_id": "ADV_TRAV_001"
     },
     {
       "id": "PATH_BASIC_003",
@@ -42,8 +42,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "Basic Path Traversal Attack",
+      "rule_id": "ADV_TRAV_001"
     },
     {
       "id": "PATH_BASIC_004",
@@ -55,8 +55,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "Basic Path Traversal Attack",
+      "rule_id": "ADV_TRAV_001"
     },
     {
       "id": "PATH_BASIC_005",
@@ -68,8 +68,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "Basic Path Traversal Attack",
+      "rule_id": "ADV_TRAV_001"
     },
     {
       "id": "PATH_DOT_001",
@@ -81,8 +81,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "critical",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "Basic Path Traversal Attack",
+      "rule_id": "ADV_TRAV_001"
     },
     {
       "id": "PATH_DOT_002",
@@ -94,8 +94,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "critical",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "Basic Path Traversal Attack",
+      "rule_id": "ADV_TRAV_001"
     },
     {
       "id": "PATH_DOT_003",
@@ -107,8 +107,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "Basic Path Traversal Attack",
+      "rule_id": "ADV_TRAV_001"
     },
     {
       "id": "PATH_DOT_004",
@@ -120,8 +120,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "Basic Path Traversal Attack",
+      "rule_id": "ADV_TRAV_001"
     },
     {
       "id": "PATH_DOT_005",
@@ -133,8 +133,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "Basic Path Traversal Attack",
+      "rule_id": "ADV_TRAV_001"
     },
     {
       "id": "PATH_DOT_006",
@@ -146,8 +146,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "medium",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "Basic Path Traversal Attack",
+      "rule_id": "ADV_TRAV_001"
     },
     {
       "id": "PATH_DOT_007",
@@ -159,8 +159,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "medium",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "Basic Path Traversal Attack",
+      "rule_id": "ADV_TRAV_001"
     },
     {
       "id": "PATH_DOT_008",
@@ -172,8 +172,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "critical",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "Basic Path Traversal Attack",
+      "rule_id": "ADV_TRAV_001"
     },
     {
       "id": "PATH_DOT_009",
@@ -185,8 +185,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "critical",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "Basic Path Traversal Attack",
+      "rule_id": "ADV_TRAV_001"
     },
     {
       "id": "PATH_DOT_010",
@@ -198,8 +198,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "Basic Path Traversal Attack",
+      "rule_id": "ADV_TRAV_001"
     },
     {
       "id": "PATH_ABS_001",
@@ -211,8 +211,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "critical",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "File Inclusion Attack",
+      "rule_id": "ADV_TRAV_004"
     },
     {
       "id": "PATH_ABS_002",
@@ -224,8 +224,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "critical",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "File Inclusion Attack",
+      "rule_id": "ADV_TRAV_004"
     },
     {
       "id": "PATH_ABS_003",
@@ -237,8 +237,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "critical",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "File Inclusion Attack",
+      "rule_id": "ADV_TRAV_004"
     },
     {
       "id": "PATH_ABS_004",
@@ -250,8 +250,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "File Inclusion Attack",
+      "rule_id": "ADV_TRAV_004"
     },
     {
       "id": "PATH_ABS_005",
@@ -263,8 +263,8 @@
       "port": 8003,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Advanced Path Traversal Attack",
-      "rule_id": "ADV_PATH_001"
+      "expected_rule": "File Inclusion Attack",
+      "rule_id": "ADV_TRAV_004"
     }
   ]
 }

--- a/e2e/patterns/sqli_patterns.json
+++ b/e2e/patterns/sqli_patterns.json
@@ -211,7 +211,7 @@
       "port": 8001,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Boolean-based SQL Injection",
+      "expected_rule": "Boolean-based Blind SQL Injection",
       "rule_id": "ADV_SQLI_002"
     },
     {
@@ -224,7 +224,7 @@
       "port": 8001,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Boolean-based SQL Injection",
+      "expected_rule": "Boolean-based Blind SQL Injection",
       "rule_id": "ADV_SQLI_002"
     },
     {
@@ -237,7 +237,7 @@
       "port": 8001,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Boolean-based SQL Injection",
+      "expected_rule": "Boolean-based Blind SQL Injection",
       "rule_id": "ADV_SQLI_002"
     },
     {
@@ -250,7 +250,7 @@
       "port": 8001,
       "expected_detection": true,
       "severity": "high",
-      "expected_rule": "Boolean-based SQL Injection",
+      "expected_rule": "Boolean-based Blind SQL Injection",
       "rule_id": "ADV_SQLI_002"
     }
   ]


### PR DESCRIPTION
## Summary

Fixes #12 - Rule Mismatch in Allure Report

The Allure Report was showing "MISMATCH" status because the `expected_rule` values in pattern files did not match the actual Falco rule names defined in `nginx_rules.yaml`.

## Changes

### Pattern Files Updated (39 patterns total)

| File | Patterns | Change |
|------|----------|--------|
| sqli_patterns.json | 4 (SQLI_BOOL_001-004) | `Boolean-based SQL Injection` → `Boolean-based Blind SQL Injection` |
| path_patterns.json | 15 (PATH_BASIC/DOT) | → `Basic Path Traversal Attack` |
| path_patterns.json | 5 (PATH_ABS) | → `File Inclusion Attack` |
| cmdinj_patterns.json | 4 (001,005,006,009) | → `Command Injection via Semicolon` |
| cmdinj_patterns.json | 2 (003,008) | → `Command Injection via Pipe` |
| cmdinj_patterns.json | 4 (002,004,007,010) | → `Advanced Command Injection Attempt` |
| other_patterns.json | 5 (EMRG_MONGO) | `Emerging Threat: NoSQL/MongoDB Injection` → `MongoDB NoSQL Injection Detection` |

## Test Plan

- [ ] E2E Security Tests workflow passes
- [ ] Allure Report shows "MATCH" for all 65 patterns
- [ ] 100% detection rate maintained

## Related Documents

- Task Definition: `claudedocs/ISSUE_12_RULE_MISMATCH_FIX_TASK.md`
- Analysis: `claudedocs/PATTERN_A318_RULE_MISMATCH_ANALYSIS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)