### PR TITLE
fix: Use case-insensitive rule matching to fix MISMATCH issue

### DIFF
--- a/e2e/allure/test_e2e_wrapper.py
+++ b/e2e/allure/test_e2e_wrapper.py
@@ -212,10 +212,12 @@ def test_e2e_with_logs(request, test_result: Dict):
     actual_rule = test_result.get('rule_name', 'N/A')
     rule_id = pattern_info.get('rule_id', 'N/A') if pattern_info else 'N/A'
 
-    # Check if expected rule matches actual rule
+    # Check if expected rule matches actual rule (case-insensitive)
     rule_match_status = ""
     if expected_rule != 'N/A' and actual_rule and actual_rule != 'N/A':
-        if expected_rule in actual_rule or actual_rule in expected_rule:
+        expected_lower = expected_rule.lower()
+        actual_lower = actual_rule.lower()
+        if expected_lower in actual_lower or actual_lower in expected_lower:
             rule_match_status = "MATCH"
         else:
             rule_match_status = "MISMATCH"


### PR DESCRIPTION
## Summary

Fixes the remaining MISMATCH issue in Allure Report discovered after Issue #12 fix.

## Root Cause

The rule matching logic in `test_e2e_wrapper.py` was case-sensitive:

```python
# Before (case-sensitive)
if expected_rule in actual_rule or actual_rule in expected_rule:
```

This caused MISMATCH for rules where the case differs:
- **Expected**: `Advanced Command Injection Attempt`
- **Actual**: `[NGINX CMDi] Advanced command injection attempt...` (lowercase "attempt")

## Fix

Added case-insensitive comparison using `.lower()`:

```python
# After (case-insensitive)
expected_lower = expected_rule.lower()
actual_lower = actual_rule.lower()
if expected_lower in actual_lower or actual_lower in expected_lower:
```

## Test Plan

- [ ] E2E Tests pass
- [ ] All 65 patterns show MATCH in Allure Report
- [ ] No MISMATCH status for any pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)