### PR TITLE
refactor: Remove Match Status feature from Allure Report

### DIFF
--- a/e2e/allure/test_e2e_wrapper.py
+++ b/e2e/allure/test_e2e_wrapper.py
@@ -207,20 +207,8 @@ def test_e2e_with_logs(request, test_result: Dict):
     # Load pattern information
     pattern_info = load_pattern_info(pattern_id)
 
-    # Get expected rule information
-    expected_rule = pattern_info.get('expected_rule', 'N/A') if pattern_info else 'N/A'
+    # Get rule information from test result
     actual_rule = test_result.get('rule_name', 'N/A')
-    rule_id = pattern_info.get('rule_id', 'N/A') if pattern_info else 'N/A'
-
-    # Check if expected rule matches actual rule (case-insensitive)
-    rule_match_status = ""
-    if expected_rule != 'N/A' and actual_rule and actual_rule != 'N/A':
-        expected_lower = expected_rule.lower()
-        actual_lower = actual_rule.lower()
-        if expected_lower in actual_lower or actual_lower in expected_lower:
-            rule_match_status = "MATCH"
-        else:
-            rule_match_status = "MISMATCH"
 
     # Build description
     if pattern_info:
@@ -240,15 +228,6 @@ def test_e2e_with_logs(request, test_result: Dict):
 - **Payload**: `{pattern_info.get('payload', 'N/A')}`
 - **Encoded**: `{pattern_info.get('encoded', 'N/A')}`
 - **Expected Detection**: {'Yes' if pattern_info.get('expected_detection') else 'No'}
-
-## Rule Mapping
-
-| Item | Value |
-|------|-------|
-| **Rule ID** | `{rule_id}` |
-| **Expected Rule** | {expected_rule} |
-| **Actual Rule** | {actual_rule if actual_rule else 'N/A'} |
-| **Match Status** | {'`' + rule_match_status + '`' if rule_match_status else 'N/A'} |
 
 ## Test Execution Results
 

--- a/e2e/patterns/cmdinj_patterns.json
+++ b/e2e/patterns/cmdinj_patterns.json
@@ -15,9 +15,7 @@
       "encoded": "%3B%20ls%20-la",
       "port": 8004,
       "expected_detection": true,
-      "severity": "critical",
-      "expected_rule": "Command Injection via Semicolon",
-      "rule_id": "ADV_CMDI_001"
+      "severity": "critical"
     },
     {
       "id": "CMD_BASIC_002",
@@ -28,9 +26,7 @@
       "encoded": "%26%26%20whoami",
       "port": 8004,
       "expected_detection": true,
-      "severity": "critical",
-      "expected_rule": "Advanced Command Injection Attempt",
-      "rule_id": "ADV_CMDI_004"
+      "severity": "critical"
     },
     {
       "id": "CMD_BASIC_003",
@@ -41,9 +37,7 @@
       "encoded": "%7C%7C%20id",
       "port": 8004,
       "expected_detection": true,
-      "severity": "critical",
-      "expected_rule": "Command Injection via Pipe",
-      "rule_id": "ADV_CMDI_002"
+      "severity": "critical"
     },
     {
       "id": "CMD_BASIC_004",
@@ -54,9 +48,7 @@
       "encoded": "%26%20ps%20aux",
       "port": 8004,
       "expected_detection": true,
-      "severity": "critical",
-      "expected_rule": "Advanced Command Injection Attempt",
-      "rule_id": "ADV_CMDI_004"
+      "severity": "critical"
     },
     {
       "id": "CMD_BASIC_005",
@@ -67,9 +59,7 @@
       "encoded": "%3B%20cat%20/etc/passwd",
       "port": 8004,
       "expected_detection": true,
-      "severity": "critical",
-      "expected_rule": "Command Injection via Semicolon",
-      "rule_id": "ADV_CMDI_001"
+      "severity": "critical"
     },
     {
       "id": "CMD_BASIC_006",
@@ -80,9 +70,7 @@
       "encoded": "%3B%20uname%20-a",
       "port": 8004,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Command Injection via Semicolon",
-      "rule_id": "ADV_CMDI_001"
+      "severity": "high"
     },
     {
       "id": "CMD_BASIC_007",
@@ -93,9 +81,7 @@
       "encoded": "%26%26%20netstat%20-an",
       "port": 8004,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Advanced Command Injection Attempt",
-      "rule_id": "ADV_CMDI_004"
+      "severity": "high"
     },
     {
       "id": "CMD_BASIC_008",
@@ -106,9 +92,7 @@
       "encoded": "%7C%7C%20cat%20/proc/version",
       "port": 8004,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Command Injection via Pipe",
-      "rule_id": "ADV_CMDI_002"
+      "severity": "high"
     },
     {
       "id": "CMD_BASIC_009",
@@ -119,9 +103,7 @@
       "encoded": "%3B%20ifconfig",
       "port": 8004,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Command Injection via Semicolon",
-      "rule_id": "ADV_CMDI_001"
+      "severity": "high"
     },
     {
       "id": "CMD_BASIC_010",
@@ -132,9 +114,7 @@
       "encoded": "%26%26%20df%20-h",
       "port": 8004,
       "expected_detection": true,
-      "severity": "medium",
-      "expected_rule": "Advanced Command Injection Attempt",
-      "rule_id": "ADV_CMDI_004"
+      "severity": "medium"
     }
   ]
 }

--- a/e2e/patterns/other_patterns.json
+++ b/e2e/patterns/other_patterns.json
@@ -15,9 +15,7 @@
       "encoded": "%7B%22%24where%22%3A%20%22this.username%20%3D%3D%20%27admin%27%22%7D",
       "port": 8005,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "MongoDB NoSQL Injection Detection",
-      "rule_id": "EMRG_NOSQL_001"
+      "severity": "high"
     },
     {
       "id": "EMRG_MONGO_002",
@@ -28,9 +26,7 @@
       "encoded": "%7B%22%24ne%22%3A%20null%7D",
       "port": 8005,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "MongoDB NoSQL Injection Detection",
-      "rule_id": "EMRG_NOSQL_001"
+      "severity": "high"
     },
     {
       "id": "EMRG_MONGO_003",
@@ -41,9 +37,7 @@
       "encoded": "%7B%22%24gt%22%3A%20%22%22%7D",
       "port": 8005,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "MongoDB NoSQL Injection Detection",
-      "rule_id": "EMRG_NOSQL_001"
+      "severity": "high"
     },
     {
       "id": "EMRG_MONGO_004",
@@ -54,9 +48,7 @@
       "encoded": "%7B%22%24regex%22%3A%20%22.%2A%22%7D",
       "port": 8005,
       "expected_detection": true,
-      "severity": "medium",
-      "expected_rule": "MongoDB NoSQL Injection Detection",
-      "rule_id": "EMRG_NOSQL_001"
+      "severity": "medium"
     },
     {
       "id": "EMRG_MONGO_005",
@@ -67,9 +59,7 @@
       "encoded": "%27%3B%20return%20db.users.find%28%29%3B%20//",
       "port": 8005,
       "expected_detection": true,
-      "severity": "critical",
-      "expected_rule": "MongoDB NoSQL Injection Detection",
-      "rule_id": "EMRG_NOSQL_001"
+      "severity": "critical"
     }
   ]
 }

--- a/e2e/patterns/path_patterns.json
+++ b/e2e/patterns/path_patterns.json
@@ -15,9 +15,7 @@
       "encoded": "../",
       "port": 8003,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Basic Path Traversal Attack",
-      "rule_id": "ADV_TRAV_001"
+      "severity": "high"
     },
     {
       "id": "PATH_BASIC_002",
@@ -28,9 +26,7 @@
       "encoded": "../../",
       "port": 8003,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Basic Path Traversal Attack",
-      "rule_id": "ADV_TRAV_001"
+      "severity": "high"
     },
     {
       "id": "PATH_BASIC_003",
@@ -41,9 +37,7 @@
       "encoded": "../../../",
       "port": 8003,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Basic Path Traversal Attack",
-      "rule_id": "ADV_TRAV_001"
+      "severity": "high"
     },
     {
       "id": "PATH_BASIC_004",
@@ -54,9 +48,7 @@
       "encoded": "../../../../",
       "port": 8003,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Basic Path Traversal Attack",
-      "rule_id": "ADV_TRAV_001"
+      "severity": "high"
     },
     {
       "id": "PATH_BASIC_005",
@@ -67,9 +59,7 @@
       "encoded": "../../../../../",
       "port": 8003,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Basic Path Traversal Attack",
-      "rule_id": "ADV_TRAV_001"
+      "severity": "high"
     },
     {
       "id": "PATH_DOT_001",
@@ -80,9 +70,7 @@
       "encoded": "../etc/passwd",
       "port": 8003,
       "expected_detection": true,
-      "severity": "critical",
-      "expected_rule": "Basic Path Traversal Attack",
-      "rule_id": "ADV_TRAV_001"
+      "severity": "critical"
     },
     {
       "id": "PATH_DOT_002",
@@ -93,9 +81,7 @@
       "encoded": "../../etc/shadow",
       "port": 8003,
       "expected_detection": true,
-      "severity": "critical",
-      "expected_rule": "Basic Path Traversal Attack",
-      "rule_id": "ADV_TRAV_001"
+      "severity": "critical"
     },
     {
       "id": "PATH_DOT_003",
@@ -106,9 +92,7 @@
       "encoded": "../../../etc/hosts",
       "port": 8003,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Basic Path Traversal Attack",
-      "rule_id": "ADV_TRAV_001"
+      "severity": "high"
     },
     {
       "id": "PATH_DOT_004",
@@ -119,9 +103,7 @@
       "encoded": "../../../../etc/apache2/apache2.conf",
       "port": 8003,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Basic Path Traversal Attack",
-      "rule_id": "ADV_TRAV_001"
+      "severity": "high"
     },
     {
       "id": "PATH_DOT_005",
@@ -132,9 +114,7 @@
       "encoded": "../../../../../etc/ssh/sshd_config",
       "port": 8003,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Basic Path Traversal Attack",
-      "rule_id": "ADV_TRAV_001"
+      "severity": "high"
     },
     {
       "id": "PATH_DOT_006",
@@ -145,9 +125,7 @@
       "encoded": "../../var/log/apache2/access.log",
       "port": 8003,
       "expected_detection": true,
-      "severity": "medium",
-      "expected_rule": "Basic Path Traversal Attack",
-      "rule_id": "ADV_TRAV_001"
+      "severity": "medium"
     },
     {
       "id": "PATH_DOT_007",
@@ -158,9 +136,7 @@
       "encoded": "../../../proc/version",
       "port": 8003,
       "expected_detection": true,
-      "severity": "medium",
-      "expected_rule": "Basic Path Traversal Attack",
-      "rule_id": "ADV_TRAV_001"
+      "severity": "medium"
     },
     {
       "id": "PATH_DOT_008",
@@ -171,9 +147,7 @@
       "encoded": "../../../../root/.bash_history",
       "port": 8003,
       "expected_detection": true,
-      "severity": "critical",
-      "expected_rule": "Basic Path Traversal Attack",
-      "rule_id": "ADV_TRAV_001"
+      "severity": "critical"
     },
     {
       "id": "PATH_DOT_009",
@@ -184,9 +158,7 @@
       "encoded": "../../home/user/.ssh/id_rsa",
       "port": 8003,
       "expected_detection": true,
-      "severity": "critical",
-      "expected_rule": "Basic Path Traversal Attack",
-      "rule_id": "ADV_TRAV_001"
+      "severity": "critical"
     },
     {
       "id": "PATH_DOT_010",
@@ -197,9 +169,7 @@
       "encoded": "../../../etc/mysql/my.cnf",
       "port": 8003,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Basic Path Traversal Attack",
-      "rule_id": "ADV_TRAV_001"
+      "severity": "high"
     },
     {
       "id": "PATH_ABS_001",
@@ -210,9 +180,7 @@
       "encoded": "/etc/passwd",
       "port": 8003,
       "expected_detection": true,
-      "severity": "critical",
-      "expected_rule": "File Inclusion Attack",
-      "rule_id": "ADV_TRAV_004"
+      "severity": "critical"
     },
     {
       "id": "PATH_ABS_002",
@@ -223,9 +191,7 @@
       "encoded": "/etc/shadow",
       "port": 8003,
       "expected_detection": true,
-      "severity": "critical",
-      "expected_rule": "File Inclusion Attack",
-      "rule_id": "ADV_TRAV_004"
+      "severity": "critical"
     },
     {
       "id": "PATH_ABS_003",
@@ -236,9 +202,7 @@
       "encoded": "/root/.ssh/authorized_keys",
       "port": 8003,
       "expected_detection": true,
-      "severity": "critical",
-      "expected_rule": "File Inclusion Attack",
-      "rule_id": "ADV_TRAV_004"
+      "severity": "critical"
     },
     {
       "id": "PATH_ABS_004",
@@ -249,9 +213,7 @@
       "encoded": "/var/log/auth.log",
       "port": 8003,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "File Inclusion Attack",
-      "rule_id": "ADV_TRAV_004"
+      "severity": "high"
     },
     {
       "id": "PATH_ABS_005",
@@ -262,9 +224,7 @@
       "encoded": "/proc/self/environ",
       "port": 8003,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "File Inclusion Attack",
-      "rule_id": "ADV_TRAV_004"
+      "severity": "high"
     }
   ]
 }

--- a/e2e/patterns/sqli_patterns.json
+++ b/e2e/patterns/sqli_patterns.json
@@ -15,9 +15,7 @@
       "encoded": "SLEEP%285%29",
       "port": 8001,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Time-based Blind SQL Injection",
-      "rule_id": "ADV_SQLI_001"
+      "severity": "high"
     },
     {
       "id": "SQLI_TIME_002",
@@ -28,9 +26,7 @@
       "encoded": "BENCHMARK%281000000%2CMD5%28%27test%27%29%29",
       "port": 8001,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Time-based Blind SQL Injection",
-      "rule_id": "ADV_SQLI_001"
+      "severity": "high"
     },
     {
       "id": "SQLI_TIME_003",
@@ -41,9 +37,7 @@
       "encoded": "WAITFOR%20DELAY%20%270%3A0%3A5%27",
       "port": 8001,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Time-based Blind SQL Injection",
-      "rule_id": "ADV_SQLI_001"
+      "severity": "high"
     },
     {
       "id": "SQLI_TIME_004",
@@ -54,9 +48,7 @@
       "encoded": "pg_sleep%285%29",
       "port": 8001,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Time-based Blind SQL Injection",
-      "rule_id": "ADV_SQLI_001"
+      "severity": "high"
     },
     {
       "id": "SQLI_TIME_005",
@@ -67,9 +59,7 @@
       "encoded": "SLEEP%2810%29",
       "port": 8001,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Time-based Blind SQL Injection",
-      "rule_id": "ADV_SQLI_001"
+      "severity": "high"
     },
     {
       "id": "SQLI_TIME_006",
@@ -80,9 +70,7 @@
       "encoded": "SLEEP%25285%2529",
       "port": 8001,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Time-based Blind SQL Injection",
-      "rule_id": "ADV_SQLI_001"
+      "severity": "high"
     },
     {
       "id": "SQLI_TIME_007",
@@ -93,9 +81,7 @@
       "encoded": "U0xFRVAoNSk%253D",
       "port": 8001,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Time-based Blind SQL Injection",
-      "rule_id": "ADV_SQLI_001"
+      "severity": "high"
     },
     {
       "id": "SQLI_TIME_008",
@@ -106,9 +92,7 @@
       "encoded": "WAITFOR%2520DELAY%2520%25270%253A0%253A5%2527",
       "port": 8001,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Time-based Blind SQL Injection",
-      "rule_id": "ADV_SQLI_001"
+      "severity": "high"
     },
     {
       "id": "SQLI_TIME_009",
@@ -119,9 +103,7 @@
       "encoded": "cGdfc2xlZXAoNSk%253D",
       "port": 8001,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Time-based Blind SQL Injection",
-      "rule_id": "ADV_SQLI_001"
+      "severity": "high"
     },
     {
       "id": "SQLI_TIME_010",
@@ -132,9 +114,7 @@
       "encoded": "SLEEP%252810%2529",
       "port": 8001,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Time-based Blind SQL Injection",
-      "rule_id": "ADV_SQLI_001"
+      "severity": "high"
     },
     {
       "id": "SQLI_TIME_011",
@@ -145,9 +125,7 @@
       "encoded": "sleep%285%29",
       "port": 8001,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Time-based Blind SQL Injection",
-      "rule_id": "ADV_SQLI_001"
+      "severity": "high"
     },
     {
       "id": "SQLI_TIME_012",
@@ -158,9 +136,7 @@
       "encoded": "SLeep%285%29",
       "port": 8001,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Time-based Blind SQL Injection",
-      "rule_id": "ADV_SQLI_001"
+      "severity": "high"
     },
     {
       "id": "SQLI_TIME_013",
@@ -171,9 +147,7 @@
       "encoded": "SLEEP/%2Acomment%2A/%285%29",
       "port": 8001,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Time-based Blind SQL Injection",
-      "rule_id": "ADV_SQLI_001"
+      "severity": "high"
     },
     {
       "id": "SQLI_TIME_014",
@@ -184,9 +158,7 @@
       "encoded": "SLEEP%28/%2A5%2A/5%29",
       "port": 8001,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Time-based Blind SQL Injection",
-      "rule_id": "ADV_SQLI_001"
+      "severity": "high"
     },
     {
       "id": "SQLI_TIME_015",
@@ -197,9 +169,7 @@
       "encoded": "/%2A%2A/SLEEP/%2A%2A/%285%29",
       "port": 8001,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Time-based Blind SQL Injection",
-      "rule_id": "ADV_SQLI_001"
+      "severity": "high"
     },
     {
       "id": "SQLI_BOOL_001",
@@ -210,9 +180,7 @@
       "encoded": "%27%20OR%20%271%27%3D%271",
       "port": 8001,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Boolean-based Blind SQL Injection",
-      "rule_id": "ADV_SQLI_002"
+      "severity": "high"
     },
     {
       "id": "SQLI_BOOL_002",
@@ -223,9 +191,7 @@
       "encoded": "%27%20OR%201%3D1%20--",
       "port": 8001,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Boolean-based Blind SQL Injection",
-      "rule_id": "ADV_SQLI_002"
+      "severity": "high"
     },
     {
       "id": "SQLI_BOOL_003",
@@ -236,9 +202,7 @@
       "encoded": "%27%20AND%20%271%27%3D%271",
       "port": 8001,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Boolean-based Blind SQL Injection",
-      "rule_id": "ADV_SQLI_002"
+      "severity": "high"
     },
     {
       "id": "SQLI_BOOL_004",
@@ -249,9 +213,7 @@
       "encoded": "%27%20OR%20%27a%27%3D%27a",
       "port": 8001,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "Boolean-based Blind SQL Injection",
-      "rule_id": "ADV_SQLI_002"
+      "severity": "high"
     }
   ]
 }

--- a/e2e/patterns/xss_patterns.json
+++ b/e2e/patterns/xss_patterns.json
@@ -15,9 +15,7 @@
       "encoded": "%3Cscript%3Ealert%28%27XSS%27%29%3C/script%3E",
       "port": 8002,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "DOM-based XSS Attack",
-      "rule_id": "ADV_XSS_001"
+      "severity": "high"
     },
     {
       "id": "XSS_REFL_002",
@@ -28,9 +26,7 @@
       "encoded": "%3Cimg%20src%3Dx%20onerror%3Dalert%28%27XSS%27%29%3E",
       "port": 8002,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "DOM-based XSS Attack",
-      "rule_id": "ADV_XSS_001"
+      "severity": "high"
     },
     {
       "id": "XSS_REFL_003",
@@ -41,9 +37,7 @@
       "encoded": "%3Csvg%20onload%3Dalert%28%27XSS%27%29%3E",
       "port": 8002,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "DOM-based XSS Attack",
-      "rule_id": "ADV_XSS_001"
+      "severity": "high"
     },
     {
       "id": "XSS_REFL_004",
@@ -54,9 +48,7 @@
       "encoded": "%3Ciframe%20src%3Djavascript%3Aalert%28%27XSS%27%29%3E",
       "port": 8002,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "DOM-based XSS Attack",
-      "rule_id": "ADV_XSS_001"
+      "severity": "high"
     },
     {
       "id": "XSS_REFL_005",
@@ -67,9 +59,7 @@
       "encoded": "%3Cbody%20onload%3Dalert%28%27XSS%27%29%3E",
       "port": 8002,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "DOM-based XSS Attack",
-      "rule_id": "ADV_XSS_001"
+      "severity": "high"
     },
     {
       "id": "XSS_REFL_006",
@@ -80,9 +70,7 @@
       "encoded": "%3Cinput%20onfocus%3Dalert%28%27XSS%27%29%20autofocus%3E",
       "port": 8002,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "DOM-based XSS Attack",
-      "rule_id": "ADV_XSS_001"
+      "severity": "high"
     },
     {
       "id": "XSS_REFL_007",
@@ -93,9 +81,7 @@
       "encoded": "%3Cselect%20onfocus%3Dalert%28%27XSS%27%29%20autofocus%3E",
       "port": 8002,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "DOM-based XSS Attack",
-      "rule_id": "ADV_XSS_001"
+      "severity": "high"
     },
     {
       "id": "XSS_REFL_008",
@@ -106,9 +92,7 @@
       "encoded": "%3Ctextarea%20onfocus%3Dalert%28%27XSS%27%29%20autofocus%3E",
       "port": 8002,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "DOM-based XSS Attack",
-      "rule_id": "ADV_XSS_001"
+      "severity": "high"
     },
     {
       "id": "XSS_REFL_009",
@@ -119,9 +103,7 @@
       "encoded": "%3Ckeygen%20onfocus%3Dalert%28%27XSS%27%29%20autofocus%3E",
       "port": 8002,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "DOM-based XSS Attack",
-      "rule_id": "ADV_XSS_001"
+      "severity": "high"
     },
     {
       "id": "XSS_REFL_010",
@@ -132,9 +114,7 @@
       "encoded": "%3Cvideo%3E%3Csource%20onerror%3Dalert%28%27XSS%27%29%3E",
       "port": 8002,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "DOM-based XSS Attack",
-      "rule_id": "ADV_XSS_001"
+      "severity": "high"
     },
     {
       "id": "XSS_REFL_011",
@@ -145,9 +125,7 @@
       "encoded": "%3Caudio%20src%3Dx%20onerror%3Dalert%28%27XSS%27%29%3E",
       "port": 8002,
       "expected_detection": true,
-      "severity": "high",
-      "expected_rule": "DOM-based XSS Attack",
-      "rule_id": "ADV_XSS_001"
+      "severity": "high"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Match Status機能を削除し、Allure Reportをシンプル化します。

## 変更理由

Match Status機能は以下の問題がありました：

1. **曖昧な部分文字列マッチング**: `expected in actual or actual in expected` は意図しないマッチ/ミスマッチを引き起こす
2. **expected_rule設定の困難さ**: どのルールがトリガーされるか事前に正確に予測するのが難しい
3. **メンテナンスコスト**: ルール名の変更時にパターンファイルも更新が必要

## 変更内容

### test_e2e_wrapper.py
- Match Status比較ロジックを削除
- Rule Mappingセクションをレポートから削除
- Actual Rule（実際にトリガーされたルール）はDetection Evidenceで引き続き表示

### パターンファイル（5ファイル）
- `expected_rule` フィールドを削除
- `rule_id` フィールドを削除

## Before / After

**Before:**
```
## Rule Mapping
| Item | Value |
|------|-------|
| Rule ID | ADV_XSS_001 |
| Expected Rule | DOM-based XSS Attack |
| Actual Rule | [NGINX XSS] XSS Filter Bypass Attempt... |
| Match Status | MISMATCH |
```

**After:**
```
## Detection Evidence

**Rule Name**: [NGINX XSS] XSS Filter Bypass Attempt...

**Falco Log Entry**:
...
```

## Test Plan

- [ ] E2E Security Testsワークフローを実行
- [ ] Allure ReportでRule Mappingセクションが削除されていることを確認
- [ ] Detection EvidenceにRule Nameが表示されていることを確認

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)