### PR TITLE
docs: Add latest URL to E2E Report Guides

### DIFF
--- a/docs/E2E_REPORT_GUIDE.md
+++ b/docs/E2E_REPORT_GUIDE.md
@@ -30,12 +30,17 @@ The E2E Security Test Report provides comprehensive visibility into the security
 
 ## Report URL
 
-The latest E2E test report is available at:
+The E2E test reports are available at the following URLs:
 
-**https://takaosgb3.github.io/falco-plugin-nginx/e2e-report/{run_number}/**
+| URL | Description |
+|-----|-------------|
+| **https://takaosgb3.github.io/falco-plugin-nginx/e2e-report/latest/** | Latest report (always points to the most recent run) |
+| **https://takaosgb3.github.io/falco-plugin-nginx/e2e-report/{run_number}/** | Specific run (e.g., run #26) |
 
-For example:
-- Run #26: https://takaosgb3.github.io/falco-plugin-nginx/e2e-report/26/
+### Examples
+
+- **Latest**: https://takaosgb3.github.io/falco-plugin-nginx/e2e-report/latest/
+- **Run #26**: https://takaosgb3.github.io/falco-plugin-nginx/e2e-report/26/
 
 ---
 

--- a/docs/E2E_REPORT_GUIDE_JA.md
+++ b/docs/E2E_REPORT_GUIDE_JA.md
@@ -28,12 +28,17 @@ E2Eセキュリティテストレポートは、Falco nginxプラグインのセ
 
 ## レポートURL
 
-最新のE2Eテストレポートは以下のURLで確認できます：
+E2Eテストレポートは以下のURLで確認できます：
 
-**https://takaosgb3.github.io/falco-plugin-nginx/e2e-report/{run_number}/**
+| URL | 説明 |
+|-----|------|
+| **https://takaosgb3.github.io/falco-plugin-nginx/e2e-report/latest/** | 最新レポート（常に最新の実行結果を表示） |
+| **https://takaosgb3.github.io/falco-plugin-nginx/e2e-report/{run_number}/** | 特定の実行（例：run #26） |
 
-例：
-- Run #26: https://takaosgb3.github.io/falco-plugin-nginx/e2e-report/26/
+### 例
+
+- **最新**: https://takaosgb3.github.io/falco-plugin-nginx/e2e-report/latest/
+- **Run #26**: https://takaosgb3.github.io/falco-plugin-nginx/e2e-report/26/
 
 ---
 


### PR DESCRIPTION
## Summary
Add the `latest` URL to both English and Japanese E2E Report Guides.

## Changes
- Add `https://takaosgb3.github.io/falco-plugin-nginx/e2e-report/latest/` URL
- Reorganize URL section with table format for better clarity
- Update both EN and JA versions

## Test plan
- [ ] Verify latest URL works correctly
- [ ] Check table renders properly in both documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)