### PR TITLE
fix: Add numeric prefix to test IDs for Allure Suites sorting

### DIFF
--- a/e2e/allure/test_e2e_wrapper.py
+++ b/e2e/allure/test_e2e_wrapper.py
@@ -400,11 +400,17 @@ def load_test_results(config) -> List[Dict]:
 
 def pytest_generate_tests(metafunc):
     """
-    Dynamically generate test cases for each E2E test result
+    Dynamically generate test cases for each E2E test result.
+
+    Test IDs are prefixed with zero-padded numbers (001_, 002_, etc.)
+    to ensure correct ordering in Allure Suites view, which sorts
+    alphabetically by default.
     """
     if 'test_result' in metafunc.fixturenames:
         results = load_test_results(metafunc.config)
-        metafunc.parametrize('test_result', results, ids=[r['pattern_id'] for r in results])
+        # Add numeric prefix for Allure UI sorting (e.g., "001_SQLI_BOOL_001")
+        ids = [f"{i+1:03d}_{r['pattern_id']}" for i, r in enumerate(results)]
+        metafunc.parametrize('test_result', results, ids=ids)
 
 
 @pytest.mark.allure


### PR DESCRIPTION
## Summary

Fix the test ordering issue in Allure Suites view.

## Problem

Allure Suites view sorts test cases **alphabetically** by default, ignoring the order in which tests were executed. This causes tests to appear out of order (e.g., `SQLI_BOOL_001` appears before `CMD_BASIC_001` due to alphabetical sorting).

## Solution

Added zero-padded numeric prefix to test IDs:
- Before: `SQLI_BOOL_001`, `SQLI_BOOL_002`, ...
- After: `001_SQLI_BOOL_001`, `002_SQLI_BOOL_002`, ...

This ensures tests appear in the correct order (#1 to #100) even with alphabetical sorting.

## Expected Result in Allure Suites

| # | Test ID |
|---|---------|
| 1 | `001_SQLI_BOOL_001` |
| 2 | `002_SQLI_BOOL_002` |
| ... | ... |
| 100 | `100_PATH_UNICODE_005` |

## Testing

The E2E workflow will run automatically. Check the Allure Suites view to verify ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)