### PR TITLE
fix: Update Test.Patterns from 65 to 100 in Allure environment

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -456,7 +456,7 @@ jobs:
           nginx.Version=$(nginx -v 2>&1 | awk -F/ '{print $NF}' || echo "unknown")
           k6.Version=$(k6 version 2>/dev/null | head -1 | awk '{print $NF}' || echo "unknown")
           Python.Version=$(python --version 2>&1 | awk '{print $2}')
-          Test.Patterns=65
+          Test.Patterns=100
           Target.Host=${{ env.TARGET_IP }}:${{ env.TARGET_PORT }}
           EOF
 


### PR DESCRIPTION
## Summary

Fix incorrect Test.Patterns value displayed in Allure report's Environment widget.

## Problem

The Environment widget in Allure report shows `Test.Patterns: 65` even though we now have 100 patterns after Phase 1 expansion.

## Root Cause

The value was hardcoded in `e2e-test.yml` workflow file:
```yaml
Test.Patterns=65  # Old value
```

## Solution

Updated to reflect the actual pattern count:
```yaml
Test.Patterns=100  # New value
```

## Result

After this fix, the Allure report Environment widget will correctly show:
- Test.Patterns: **100**

🤖 Generated with [Claude Code](https://claude.com/claude-code)