### PR TITLE
fix: Add URL-encoded patterns for API_BOLA_001 detection

### DIFF
--- a/rules/nginx_rules.yaml
+++ b/rules/nginx_rules.yaml
@@ -2234,7 +2234,9 @@
       nginx.request_uri contains "\"role\":\"admin\"" or
       nginx.request_uri contains "%22role%22%3A%22admin%22" or
       (nginx.request_uri contains "/api/" and nginx.request_uri contains "/users/" and nginx.request_uri contains "/profile") or
-      (nginx.request_uri contains "/api/" and nginx.request_uri contains "/orders/" and nginx.request_uri contains "/invoice")
+      (nginx.request_uri contains "%2Fapi%2F" and nginx.request_uri contains "%2Fusers%2F" and nginx.request_uri contains "%2Fprofile") or
+      (nginx.request_uri contains "/api/" and nginx.request_uri contains "/orders/" and nginx.request_uri contains "/invoice") or
+      (nginx.request_uri contains "%2Fapi%2F" and nginx.request_uri contains "%2Forders%2F" and nginx.request_uri contains "%2Finvoice")
     )
   output: "[NGINX API Attack] API security vulnerability detected test_id=%nginx.test_id pattern_id=%nginx.pattern_id uri=%nginx.request_uri client=%nginx.remote_addr"
   priority: WARNING


### PR DESCRIPTION
## Summary

- Fixes Issue #51: API_BOLA_001 Detection Failure
- Root cause identified as Pattern #A329: URL Encoded Path Separator Not Matched

## Problem

The Falco rule `API Security Attack Attempt` expected raw path characters:
- `/api/`, `/users/`, `/profile` for BOLA
- `/api/`, `/orders/`, `/invoice` for IDOR

However, k6 test sends URL-encoded payloads, resulting in nginx logs containing:
- `%2Fapi%2F`, `%2Fusers%2F`, `%2Fprofile` for BOLA
- `%2Fapi%2F`, `%2Forders%2F`, `%2Finvoice` for IDOR

nginx `$request` does NOT URL-decode (as documented in Pattern #A321).

## Changes

Added URL-encoded pattern conditions to the `API Security Attack Attempt` rule:
- BOLA: `%2Fapi%2F`, `%2Fusers%2F`, `%2Fprofile`
- IDOR: `%2Fapi%2F`, `%2Forders%2F`, `%2Finvoice`

## Test plan

- [ ] YAML syntax validation (Passed locally)
- [ ] E2E test to verify API_BOLA_001 detection (pending CI run)
- [ ] Verify 300/300 patterns detected

## Related

- Issue #51: https://github.com/takaosgb3/falco-plugin-nginx/issues/51
- Pattern #A329: URL Encoded Path Separator Not Matched
- Pattern #A321: nginx $request URL encoding behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)