### PR TITLE
fix(e2e): Improve display of expected_detection: false patterns (Issue #58)

### DIFF
--- a/e2e/allure/test_e2e_wrapper.py
+++ b/e2e/allure/test_e2e_wrapper.py
@@ -269,15 +269,17 @@ def format_rule_match_status(test_result: Dict) -> str:
     Format rule match status for display
 
     Issue #53: E2E ルールマッピング検証機能
-    Extracted helper to eliminate code duplication
+    Issue #58: Improve display of expected_detection: false patterns
 
     Args:
         test_result: Test result dictionary containing:
             - expected_rule: Expected rule from pattern definition
             - rule_match: Boolean indicating if rules matched
+            - expected_detection: Boolean indicating if detection is expected (default True)
 
     Returns:
         One of:
+        - "✅ Expected Not Detected" if expected_detection is exactly False (negative test case)
         - "✅ Match" if rule_match is exactly True (boolean)
         - "❌ Mismatch" if expected_rule is defined but no match
         - "⚠️ Not Defined" if expected_rule is empty, None, or N/A
@@ -287,6 +289,13 @@ def format_rule_match_status(test_result: Dict) -> str:
         String "true" or other truthy values are treated as Mismatch
         to prevent false positives from JSON parsing issues.
     """
+    # Issue #58: Check for negative test case first
+    # expected_detection: false means this pattern is intentionally not expected to be detected
+    # (e.g., Base64/Hex encoded commands that require decoding)
+    expected_detection = test_result.get('expected_detection', True)
+    if expected_detection is False:
+        return '✅ Expected Not Detected'
+
     expected_rule = test_result.get('expected_rule', '')
     # Type-safe check: only boolean True triggers match
     rule_match = test_result.get('rule_match') is True

--- a/e2e/allure/test_format_rule_match_status.py
+++ b/e2e/allure/test_format_rule_match_status.py
@@ -3,6 +3,7 @@
 Unit tests for format_rule_match_status() helper function
 
 Issue #53: E2E ルールマッピング検証機能
+Issue #58: Improve display of expected_detection: false patterns
 
 Test coverage for:
 - format_rule_match_status(): Status formatting for rule matching display
@@ -10,6 +11,90 @@ Test coverage for:
 
 import pytest
 from test_e2e_wrapper import format_rule_match_status
+
+
+class TestFormatRuleMatchStatusExpectedNotDetected:
+    """Tests for expected_detection: false patterns (Issue #58)"""
+
+    def test_expected_detection_false_returns_expected_not_detected(self):
+        """Should return 'Expected Not Detected' when expected_detection is False"""
+        test_result = {
+            'expected_detection': False,
+            'expected_rule': '',
+            'rule_match': False
+        }
+        assert format_rule_match_status(test_result) == '✅ Expected Not Detected'
+
+    def test_expected_detection_false_with_empty_expected_rule(self):
+        """CMD_ENC_003/CMD_ENC_005 pattern: expected_detection=false, expected_rule=empty"""
+        test_result = {
+            'pattern_id': 'CMD_ENC_003',
+            'detected': False,
+            'expected_detection': False,
+            'expected_rule': '',
+            'rule_match': False,
+            'matched_rule': None
+        }
+        assert format_rule_match_status(test_result) == '✅ Expected Not Detected'
+
+    def test_expected_detection_false_takes_precedence_over_empty_expected_rule(self):
+        """expected_detection: false should take precedence over empty expected_rule"""
+        test_result = {
+            'expected_detection': False,
+            'expected_rule': '',  # Would normally trigger 'Not Defined'
+            'rule_match': False
+        }
+        # Should NOT return 'Not Defined', but 'Expected Not Detected'
+        assert format_rule_match_status(test_result) == '✅ Expected Not Detected'
+
+    def test_expected_detection_false_takes_precedence_over_na(self):
+        """expected_detection: false should take precedence over N/A expected_rule"""
+        test_result = {
+            'expected_detection': False,
+            'expected_rule': 'N/A',
+            'rule_match': False
+        }
+        assert format_rule_match_status(test_result) == '✅ Expected Not Detected'
+
+    def test_expected_detection_false_even_if_detected(self):
+        """Should return 'Expected Not Detected' even if pattern was actually detected (false positive case)"""
+        test_result = {
+            'expected_detection': False,
+            'detected': True,  # Pattern was detected (false positive)
+            'expected_rule': '',
+            'rule_match': False,
+            'matched_rule': 'Some Rule'
+        }
+        # Still shows 'Expected Not Detected' because that's the expectation
+        assert format_rule_match_status(test_result) == '✅ Expected Not Detected'
+
+    def test_expected_detection_true_does_not_affect_normal_flow(self):
+        """expected_detection: true should not affect normal rule match flow"""
+        test_result = {
+            'expected_detection': True,
+            'expected_rule': '[NGINX SQLi] Advanced SQL Injection',
+            'rule_match': True
+        }
+        assert format_rule_match_status(test_result) == '✅ Match'
+
+    def test_expected_detection_missing_defaults_to_true(self):
+        """When expected_detection is missing, should default to True (normal flow)"""
+        test_result = {
+            'expected_rule': '[NGINX SQLi] Advanced SQL Injection',
+            'rule_match': True
+        }
+        # No expected_detection key, should default to True and go through normal flow
+        assert format_rule_match_status(test_result) == '✅ Match'
+
+    def test_expected_detection_string_false_not_treated_as_false(self):
+        """String 'false' should not be treated as boolean False (type safety)"""
+        test_result = {
+            'expected_detection': 'false',  # String, not boolean
+            'expected_rule': '',
+            'rule_match': False
+        }
+        # String 'false' is truthy, so should go through normal flow
+        assert format_rule_match_status(test_result) == '⚠️ Not Defined'
 
 
 class TestFormatRuleMatchStatus:
@@ -167,7 +252,10 @@ class TestFormatRuleMatchStatusIntegration:
         assert format_rule_match_status(test_result) == '❌ Mismatch'
 
     def test_no_detection_expected(self):
-        """Test result where no detection was expected (evasion test)"""
+        """Test result where no detection was expected (evasion test)
+
+        Issue #58: Updated to return 'Expected Not Detected' for negative test cases
+        """
         test_result = {
             'pattern_id': 'CMD_ENC_003',
             'detected': False,
@@ -176,7 +264,8 @@ class TestFormatRuleMatchStatusIntegration:
             'rule_match': False,
             'matched_rule': None
         }
-        assert format_rule_match_status(test_result) == '⚠️ Not Defined'
+        # Issue #58: Now returns 'Expected Not Detected' instead of 'Not Defined'
+        assert format_rule_match_status(test_result) == '✅ Expected Not Detected'
 
     def test_detection_without_expected_rule(self):
         """Test result where rule was detected but expected_rule not defined"""


### PR DESCRIPTION
## Summary

- Update `format_rule_match_status()` to check `expected_detection` field first
- Return `"✅ Expected Not Detected"` for negative test cases (`expected_detection: false`)
- Add 8 new unit tests covering `expected_detection` handling
- Update existing integration test to match new behavior

## Problem

CMD_ENC_003 and CMD_ENC_005 patterns (Base64/Hex encoded commands) were displayed as `"⚠️ Not Defined"` in the Rule Mapping status. This was confusing because:

1. These patterns have `expected_detection: false` - they are **intentional negative test cases**
2. They have `expected_rule: ""` (empty) because no rule is expected to fire
3. The old logic only looked at `expected_rule`, treating them the same as patterns where `expected_rule` was forgotten

## Solution

Check `expected_detection` **before** checking `expected_rule`:

```python
# Before (Issue #53)
if not expected_rule or expected_rule == 'N/A':
    return '⚠️ Not Defined'  # CMD_ENC_003/CMD_ENC_005 hit this branch

# After (Issue #58)
if expected_detection is False:
    return '✅ Expected Not Detected'  # Negative test cases now clearly labeled
if not expected_rule or expected_rule == 'N/A':
    return '⚠️ Not Defined'  # Only for truly undefined cases
```

## Test Plan

- [x] Run `pytest test_format_rule_match_status.py -v` - 27 tests pass
- [x] Run `pytest test_batch_analyzer.py -v` - 39 tests pass
- [ ] E2E workflow verification (automatic on PR)

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)