### PR TITLE
feat(e2e): Add Rule Mapping Trend to Allure Report

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -434,6 +434,35 @@ jobs:
           fi
 
       # ========================================
+      # 10a. Generate Rule Mapping Trend (Issue #59)
+      # ========================================
+      - name: Generate Rule Mapping Trend
+        run: |
+          echo "=========================================="
+          echo "Generating Rule Mapping Trend (Issue #59)"
+          echo "=========================================="
+
+          cd e2e
+
+          # Ensure history directory exists
+          mkdir -p allure-results/history
+
+          # Generate Rule Mapping trend data and merge with history
+          python scripts/generate_rule_mapping_trend.py \
+            --test-results results/test-results.json \
+            --run-number ${{ github.run_number }} \
+            --report-url "https://takaosgb3.github.io/falco-plugin-nginx/e2e-report/${{ github.run_number }}/" \
+            --history-input allure-results/history/categories-trend.json \
+            --history-output allure-results/history/categories-trend.json \
+            --max-history 10
+
+          echo "Rule Mapping trend data generated"
+          if [ -f allure-results/history/categories-trend.json ]; then
+            echo "=== Categories Trend (last 3 entries) ==="
+            head -50 allure-results/history/categories-trend.json
+          fi
+
+      # ========================================
       # 11. Generate Allure Report (DD-004, DD-010)
       # ========================================
       - name: Install Allure CLI
@@ -636,6 +665,28 @@ jobs:
             fi
           else
             echo "Analysis summary not available" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          # Issue #59: Add Rule Mapping statistics to summary
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -f e2e/allure-results/history/categories-trend.json ]; then
+            echo "### Rule Mapping (Issue #59)" >> $GITHUB_STEP_SUMMARY
+            CURRENT_RUN=$(jq -r '.[0]' e2e/allure-results/history/categories-trend.json)
+            MATCH=$(echo "$CURRENT_RUN" | jq -r '.data["Rule Match"] // 0')
+            MISMATCH=$(echo "$CURRENT_RUN" | jq -r '.data["Rule Mismatch"] // 0')
+            EXPECTED_NOT=$(echo "$CURRENT_RUN" | jq -r '.data["Expected Not Detected"] // 0')
+            NOT_DEF=$(echo "$CURRENT_RUN" | jq -r '.data["Not Defined"] // 0')
+            TOTAL_RM=$((MATCH + MISMATCH + EXPECTED_NOT + NOT_DEF))
+            if [ "$TOTAL_RM" -gt 0 ]; then
+              MATCH_RATE=$(echo "scale=1; $MATCH * 100 / $TOTAL_RM" | bc)
+              echo "| Status | Count |" >> $GITHUB_STEP_SUMMARY
+              echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+              echo "| Rule Match | $MATCH |" >> $GITHUB_STEP_SUMMARY
+              echo "| Rule Mismatch | $MISMATCH |" >> $GITHUB_STEP_SUMMARY
+              echo "| Expected Not Detected | $EXPECTED_NOT |" >> $GITHUB_STEP_SUMMARY
+              echo "| Not Defined | $NOT_DEF |" >> $GITHUB_STEP_SUMMARY
+              echo "| **Match Rate** | **${MATCH_RATE}%** |" >> $GITHUB_STEP_SUMMARY
+            fi
           fi
 
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/claudedocs/ISSUE_59_TASK_DEFINITION.md
+++ b/claudedocs/ISSUE_59_TASK_DEFINITION.md
@@ -1,0 +1,318 @@
+# Issue #59 Task Definition v1.1.0
+
+## Document Info
+| Item | Value |
+|------|-------|
+| Issue | [#59](https://github.com/takaosgb3/falco-plugin-nginx/issues/59) |
+| Title | E2E Report: Add Rule Mapping Trend graph to Allure Report |
+| Priority | P3 (Low) |
+| Created | 2026-01-12 |
+| Updated | 2026-01-12 |
+| Origin | Issue #56 TASK-C |
+| **Approach** | **Allure Categories Trend (既存Graphs TRENDと同形式)** |
+
+---
+
+## 1. Background
+
+Issue #56 でRule Mapping Mismatchを15件から0件に改善しました。今後もMismatch率をモニタリングするため、トレンドグラフによる可視化が有用です。
+
+### 1.1 Current State Analysis
+
+現在のE2E環境では:
+- ✅ 各テストごとにRule Mapping状態を表示 (`format_rule_match_status()`)
+- ✅ Allure標準のトレンドグラフ（pass/fail推移）が動作
+- ❌ Rule Mapping統計の集計がない
+- ❌ Rule Mapping統計の履歴保存がない
+- ❌ Rule Mapping専用のトレンドグラフがない
+
+### 1.2 Rule Mapping Status Types
+
+| Status | Meaning | Ideal State |
+|--------|---------|-------------|
+| ✅ Match | Expected rule = Matched rule | 高いほど良い |
+| ✅ Expected Not Detected | expected_detection: false | 正常（負テスト） |
+| ❌ Mismatch | Expected rule ≠ Matched rule | 0が理想 |
+| ⚠️ Not Defined | expected_rule未定義 | 減らすべき |
+
+---
+
+## 2. Functional Requirements
+
+### FR-001: Rule Mapping Statistics Calculation
+
+**As a** E2E test operator,
+**I want** Rule Mapping statistics to be calculated after each run,
+**So that** I can see the overall health of rule mappings.
+
+**Metrics to calculate:**
+```json
+{
+  "run_number": 100,
+  "timestamp": "2026-01-12T10:00:00Z",
+  "total_patterns": 100,
+  "rule_mapping": {
+    "match": 95,
+    "mismatch": 0,
+    "expected_not_detected": 3,
+    "not_defined": 2
+  },
+  "match_rate": 0.95,
+  "mismatch_rate": 0.00
+}
+```
+
+### FR-002: History Data Storage
+
+**As a** system,
+**I want** to store Rule Mapping statistics for past N runs,
+**So that** trend graphs can be rendered.
+
+**Requirements:**
+- Store last 10 runs (configurable via TREND_HISTORY_COUNT)
+- Persist in gh-pages branch (e2e-report/history/)
+- JSON format for easy parsing
+
+### FR-003: Trend Graph Visualization
+
+**As a** user viewing Allure Report,
+**I want** to see a Rule Mapping trend graph,
+**So that** I can monitor match rate over time.
+
+**Requirements:**
+- Line chart showing Match Rate % over time
+- X-axis: Run numbers (last N runs)
+- Y-axis: Rate percentage (0-100%)
+- Hover to see detailed metrics
+
+---
+
+## 3. Implementation Options Analysis
+
+### Option A: Allure History Feature Extension
+
+**Approach:** Use Allure's built-in history-trend.json mechanism
+
+**Pros:**
+- Integrated with Allure ecosystem
+- Automatic trend graph rendering
+
+**Cons:**
+- Limited customization
+- Complex to add custom metrics
+- Allure history format is designed for pass/fail only
+
+**Effort:** Medium-High
+**Recommendation:** ❌ Not recommended (limited flexibility)
+
+### Option B: Allure Custom Widget
+
+**Approach:** Add custom widget to Allure report
+
+**Pros:**
+- Appears in Allure UI
+- Can use Chart.js inside widget
+
+**Cons:**
+- Requires understanding Allure plugin system
+- May break with Allure updates
+- Complex deployment
+
+**Effort:** High
+**Recommendation:** ❌ Not recommended (complexity vs benefit)
+
+### Option C: Separate Dashboard on GitHub Pages ⭐ RECOMMENDED
+
+**Approach:** Create standalone HTML dashboard alongside Allure Report
+
+**Pros:**
+- Full control over visualization
+- Simple implementation
+- Easy to maintain
+- Works independently of Allure
+- Can use Chart.js or similar
+
+**Cons:**
+- Not integrated into Allure UI (separate page)
+
+**Effort:** Low-Medium
+**Recommendation:** ✅ Recommended (best effort/value ratio for P3)
+
+---
+
+## 4. Implementation Plan (Option C)
+
+### 4.1 New Files to Create
+
+```
+e2e/
+├── scripts/
+│   └── generate_trend_data.py     # Calculate and store trend data
+├── trend-dashboard/
+│   └── index.html                 # Standalone trend dashboard
+└── ...
+```
+
+### 4.2 Workflow Changes
+
+```yaml
+# e2e-test.yml additions
+
+# After step 9 (Analyze test results):
+- name: Generate trend data
+  run: |
+    python e2e/scripts/generate_trend_data.py \
+      --results e2e/results/test-results.json \
+      --run-number ${{ github.run_number }} \
+      --output e2e/trend-data.json
+
+# Modified step 10 (Download history):
+- name: Download trend history
+  run: |
+    # Download existing trend-history.json from gh-pages
+    git show gh-pages:e2e-report/history/trend-history.json > trend-history.json || echo "[]" > trend-history.json
+
+# After step 11 (Generate Allure Report):
+- name: Generate trend dashboard
+  run: |
+    # Merge new data into history
+    python e2e/scripts/merge_trend_history.py \
+      --new-data e2e/trend-data.json \
+      --history trend-history.json \
+      --output e2e/trend-dashboard/trend-history.json
+
+    # Copy dashboard template
+    cp e2e/trend-dashboard/index.html e2e/allure-report/trend/
+    cp e2e/trend-dashboard/trend-history.json e2e/allure-report/trend/
+
+# Deploy includes trend dashboard and history
+```
+
+### 4.3 Task Breakdown
+
+| Task | Description | Effort |
+|------|-------------|--------|
+| TASK-1 | Create `generate_trend_data.py` | 1h |
+| TASK-2 | Create `merge_trend_history.py` | 0.5h |
+| TASK-3 | Create `trend-dashboard/index.html` with Chart.js | 1h |
+| TASK-4 | Update `e2e-test.yml` workflow | 0.5h |
+| TASK-5 | Test and verify | 0.5h |
+| TASK-6 | Documentation | 0.5h |
+| **Total** | | **4h** |
+
+---
+
+## 5. Detailed Task Specifications
+
+### TASK-1: generate_trend_data.py
+
+**Purpose:** Calculate Rule Mapping statistics from test-results.json
+
+**Input:** `e2e/results/test-results.json`
+**Output:** `e2e/trend-data.json`
+
+```python
+#!/usr/bin/env python3
+"""Generate trend data from test results"""
+
+def calculate_rule_mapping_stats(test_results: List[Dict]) -> Dict:
+    """
+    Calculate Rule Mapping statistics from test results
+
+    Returns:
+        {
+            "match": count,
+            "mismatch": count,
+            "expected_not_detected": count,
+            "not_defined": count,
+            "match_rate": float,
+            "mismatch_rate": float
+        }
+    """
+    # Logic based on format_rule_match_status() from test_e2e_wrapper.py
+```
+
+### TASK-2: merge_trend_history.py
+
+**Purpose:** Merge new run data into history, keep last N runs
+
+**Input:**
+- `e2e/trend-data.json` (new data)
+- `trend-history.json` (existing history)
+
+**Output:** `e2e/trend-dashboard/trend-history.json`
+
+```python
+#!/usr/bin/env python3
+"""Merge trend data into history"""
+
+def merge_and_trim(new_data: Dict, history: List[Dict], max_runs: int = 10) -> List[Dict]:
+    """
+    Append new data to history and keep only last N runs
+    """
+```
+
+### TASK-3: trend-dashboard/index.html
+
+**Purpose:** Standalone dashboard with Chart.js visualization
+
+**Features:**
+- Line chart: Match Rate % over time
+- Stacked bar chart: Status breakdown per run
+- Table: Detailed metrics per run
+- Responsive design
+- Dark theme (matches Allure style)
+
+### TASK-4: Workflow Integration
+
+**Changes to e2e-test.yml:**
+1. Add step to generate trend data
+2. Modify history download to include trend-history.json
+3. Add step to generate trend dashboard
+4. Update deploy to include trend/ directory
+
+### TASK-5: Testing
+
+- Local test with sample data
+- Full E2E workflow run
+- Verify trend graph renders correctly
+- Verify history accumulates correctly
+
+### TASK-6: Documentation
+
+- Update e2e/README.md with trend dashboard info
+- Add link to trend dashboard in Allure Report
+- Document configuration options
+
+---
+
+## 6. Acceptance Criteria
+
+- [ ] Rule Mapping統計が各E2E実行後に計算される
+- [ ] 過去10回分の統計が履歴として保存される
+- [ ] トレンドダッシュボードがGitHub Pagesで公開される
+- [ ] Match Rate %の推移がグラフで確認できる
+- [ ] ダッシュボードへのリンクがAllure Reportに含まれる
+
+---
+
+## 7. Out of Scope
+
+- Allure UIへの直接統合
+- カテゴリ別のトレンド分析
+- 自動アラート（Match Rateが低下した場合）
+
+---
+
+## 8. References
+
+- [Issue #59](https://github.com/takaosgb3/falco-plugin-nginx/issues/59)
+- [Issue #56](https://github.com/takaosgb3/falco-plugin-nginx/issues/56)
+- [test_e2e_wrapper.py](../e2e/allure/test_e2e_wrapper.py)
+- [e2e-test.yml](../.github/workflows/e2e-test.yml)
+- [Chart.js Documentation](https://www.chartjs.org/docs/latest/)
+
+---
+
+*Document Version: 1.0.0*
+*Created: 2026-01-12*

--- a/e2e/scripts/generate_rule_mapping_trend.py
+++ b/e2e/scripts/generate_rule_mapping_trend.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""
+Generate Rule Mapping Trend Data for Allure Categories Trend
+
+Issue #59: Add Rule Mapping Trend graph to Allure Report
+
+This script calculates Rule Mapping statistics from test-results.json and
+generates/updates categories-trend.json for Allure's Categories Trend graph.
+
+Usage:
+    python generate_rule_mapping_trend.py \
+        --test-results results/test-results.json \
+        --run-number 100 \
+        --report-url "https://example.com/100/" \
+        --history-input allure-results/history/categories-trend.json \
+        --history-output allure-results/history/categories-trend.json \
+        --max-history 10
+"""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Rule Mapping status categories (matching format_rule_match_status in test_e2e_wrapper.py)
+CATEGORY_MATCH = "Rule Match"
+CATEGORY_MISMATCH = "Rule Mismatch"
+CATEGORY_EXPECTED_NOT_DETECTED = "Expected Not Detected"
+CATEGORY_NOT_DEFINED = "Not Defined"
+
+
+def calculate_rule_mapping_status(test_result: Dict) -> str:
+    """
+    Calculate Rule Mapping status for a single test result.
+
+    This logic mirrors format_rule_match_status() in test_e2e_wrapper.py
+
+    Args:
+        test_result: Test result dictionary
+
+    Returns:
+        One of: CATEGORY_MATCH, CATEGORY_MISMATCH,
+                CATEGORY_EXPECTED_NOT_DETECTED, CATEGORY_NOT_DEFINED
+    """
+    # Check for negative test case first (Issue #58)
+    expected_detection = test_result.get('expected_detection', True)
+    if expected_detection is False:
+        return CATEGORY_EXPECTED_NOT_DETECTED
+
+    expected_rule = test_result.get('expected_rule', '')
+    rule_match = test_result.get('rule_match') is True
+
+    if not expected_rule or expected_rule == 'N/A':
+        return CATEGORY_NOT_DEFINED
+    if rule_match:
+        return CATEGORY_MATCH
+    return CATEGORY_MISMATCH
+
+
+def calculate_statistics(test_results: List[Dict]) -> Dict[str, int]:
+    """
+    Calculate Rule Mapping statistics from test results.
+
+    Args:
+        test_results: List of test result dictionaries
+
+    Returns:
+        Dictionary with category counts:
+        {
+            "Rule Match": 95,
+            "Rule Mismatch": 0,
+            "Expected Not Detected": 3,
+            "Not Defined": 2
+        }
+    """
+    stats = {
+        CATEGORY_MATCH: 0,
+        CATEGORY_MISMATCH: 0,
+        CATEGORY_EXPECTED_NOT_DETECTED: 0,
+        CATEGORY_NOT_DEFINED: 0
+    }
+
+    for result in test_results:
+        status = calculate_rule_mapping_status(result)
+        stats[status] += 1
+
+    return stats
+
+
+def create_trend_entry(
+    run_number: int,
+    report_url: str,
+    stats: Dict[str, int]
+) -> Dict:
+    """
+    Create a single trend entry for categories-trend.json
+
+    Args:
+        run_number: GitHub Actions run number
+        report_url: URL to the Allure report
+        stats: Rule Mapping statistics
+
+    Returns:
+        Trend entry dictionary
+    """
+    return {
+        "buildOrder": run_number,
+        "reportName": f"E2E Tests #{run_number}",
+        "reportUrl": report_url,
+        "data": stats
+    }
+
+
+def merge_trend_history(
+    new_entry: Dict,
+    existing_history: List[Dict],
+    max_history: int = 10
+) -> List[Dict]:
+    """
+    Merge new trend entry into existing history, keeping only the last N entries.
+
+    Args:
+        new_entry: New trend entry to add
+        existing_history: Existing history entries
+        max_history: Maximum number of entries to keep
+
+    Returns:
+        Updated history list (newest first)
+    """
+    # Add new entry at the beginning
+    updated = [new_entry] + existing_history
+
+    # Remove duplicates (same buildOrder)
+    seen = set()
+    deduplicated = []
+    for entry in updated:
+        build_order = entry.get('buildOrder')
+        if build_order not in seen:
+            seen.add(build_order)
+            deduplicated.append(entry)
+
+    # Sort by buildOrder descending (newest first)
+    deduplicated.sort(key=lambda x: x.get('buildOrder', 0), reverse=True)
+
+    # Keep only the last N entries
+    return deduplicated[:max_history]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate Rule Mapping Trend Data for Allure (Issue #59)'
+    )
+    parser.add_argument(
+        '--test-results',
+        required=True,
+        help='Path to test-results.json'
+    )
+    parser.add_argument(
+        '--run-number',
+        type=int,
+        required=True,
+        help='GitHub Actions run number'
+    )
+    parser.add_argument(
+        '--report-url',
+        default='',
+        help='URL to the Allure report'
+    )
+    parser.add_argument(
+        '--history-input',
+        help='Path to existing categories-trend.json (optional)'
+    )
+    parser.add_argument(
+        '--history-output',
+        required=True,
+        help='Output path for updated categories-trend.json'
+    )
+    parser.add_argument(
+        '--max-history',
+        type=int,
+        default=10,
+        help='Maximum number of history entries to keep (default: 10)'
+    )
+    parser.add_argument(
+        '--verbose',
+        action='store_true',
+        help='Enable verbose logging'
+    )
+
+    args = parser.parse_args()
+
+    # Configure logging
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format='%(levelname)s: %(message)s'
+    )
+
+    # Load test results
+    test_results_path = Path(args.test_results)
+    if not test_results_path.exists():
+        logger.error(f"Test results file not found: {args.test_results}")
+        sys.exit(1)
+
+    with open(test_results_path, 'r') as f:
+        test_results = json.load(f)
+
+    logger.info(f"Loaded {len(test_results)} test results")
+
+    # Calculate statistics
+    stats = calculate_statistics(test_results)
+    logger.info(f"Rule Mapping Statistics: {stats}")
+
+    # Create new trend entry
+    new_entry = create_trend_entry(
+        run_number=args.run_number,
+        report_url=args.report_url,
+        stats=stats
+    )
+
+    # Load existing history
+    existing_history = []
+    if args.history_input:
+        history_path = Path(args.history_input)
+        if history_path.exists():
+            try:
+                with open(history_path, 'r') as f:
+                    existing_history = json.load(f)
+                logger.info(f"Loaded {len(existing_history)} existing history entries")
+            except (json.JSONDecodeError, IOError) as e:
+                logger.warning(f"Could not load existing history: {e}")
+
+    # Merge with existing history
+    updated_history = merge_trend_history(
+        new_entry=new_entry,
+        existing_history=existing_history,
+        max_history=args.max_history
+    )
+
+    # Write output
+    output_path = Path(args.history_output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(output_path, 'w') as f:
+        json.dump(updated_history, f, indent=2)
+
+    logger.info(f"Written {len(updated_history)} history entries to {args.history_output}")
+
+    # Print summary
+    total = sum(stats.values())
+    match_rate = (stats[CATEGORY_MATCH] / total * 100) if total > 0 else 0
+
+    print(f"\n{'='*50}")
+    print("Rule Mapping Trend Data Generated (Issue #59)")
+    print(f"{'='*50}")
+    print(f"Run Number: {args.run_number}")
+    print(f"Total Patterns: {total}")
+    print(f"  - {CATEGORY_MATCH}: {stats[CATEGORY_MATCH]}")
+    print(f"  - {CATEGORY_MISMATCH}: {stats[CATEGORY_MISMATCH]}")
+    print(f"  - {CATEGORY_EXPECTED_NOT_DETECTED}: {stats[CATEGORY_EXPECTED_NOT_DETECTED]}")
+    print(f"  - {CATEGORY_NOT_DEFINED}: {stats[CATEGORY_NOT_DEFINED]}")
+    print(f"Match Rate: {match_rate:.1f}%")
+    print(f"{'='*50}")
+
+
+if __name__ == '__main__':
+    main()

--- a/e2e/scripts/test_generate_rule_mapping_trend.py
+++ b/e2e/scripts/test_generate_rule_mapping_trend.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+Unit tests for generate_rule_mapping_trend.py
+
+Issue #59: Add Rule Mapping Trend graph to Allure Report
+"""
+
+import pytest
+from generate_rule_mapping_trend import (
+    calculate_rule_mapping_status,
+    calculate_statistics,
+    create_trend_entry,
+    merge_trend_history,
+    CATEGORY_MATCH,
+    CATEGORY_MISMATCH,
+    CATEGORY_EXPECTED_NOT_DETECTED,
+    CATEGORY_NOT_DEFINED
+)
+
+
+class TestCalculateRuleMappingStatus:
+    """Tests for calculate_rule_mapping_status()"""
+
+    def test_rule_match_true_returns_match(self):
+        """Should return CATEGORY_MATCH when rule_match is True"""
+        result = {
+            'expected_rule': 'Some Rule',
+            'rule_match': True
+        }
+        assert calculate_rule_mapping_status(result) == CATEGORY_MATCH
+
+    def test_rule_match_false_returns_mismatch(self):
+        """Should return CATEGORY_MISMATCH when rule_match is False"""
+        result = {
+            'expected_rule': 'Some Rule',
+            'rule_match': False
+        }
+        assert calculate_rule_mapping_status(result) == CATEGORY_MISMATCH
+
+    def test_empty_expected_rule_returns_not_defined(self):
+        """Should return CATEGORY_NOT_DEFINED when expected_rule is empty"""
+        result = {
+            'expected_rule': '',
+            'rule_match': False
+        }
+        assert calculate_rule_mapping_status(result) == CATEGORY_NOT_DEFINED
+
+    def test_na_expected_rule_returns_not_defined(self):
+        """Should return CATEGORY_NOT_DEFINED when expected_rule is N/A"""
+        result = {
+            'expected_rule': 'N/A',
+            'rule_match': False
+        }
+        assert calculate_rule_mapping_status(result) == CATEGORY_NOT_DEFINED
+
+    def test_expected_detection_false_returns_expected_not_detected(self):
+        """Should return CATEGORY_EXPECTED_NOT_DETECTED when expected_detection is False"""
+        result = {
+            'expected_detection': False,
+            'expected_rule': '',
+            'rule_match': False
+        }
+        assert calculate_rule_mapping_status(result) == CATEGORY_EXPECTED_NOT_DETECTED
+
+    def test_expected_detection_false_takes_precedence(self):
+        """expected_detection: false should take precedence over other conditions"""
+        result = {
+            'expected_detection': False,
+            'expected_rule': 'Some Rule',
+            'rule_match': True
+        }
+        assert calculate_rule_mapping_status(result) == CATEGORY_EXPECTED_NOT_DETECTED
+
+    def test_missing_expected_detection_defaults_to_true(self):
+        """Missing expected_detection should default to True (normal flow)"""
+        result = {
+            'expected_rule': 'Some Rule',
+            'rule_match': True
+        }
+        assert calculate_rule_mapping_status(result) == CATEGORY_MATCH
+
+
+class TestCalculateStatistics:
+    """Tests for calculate_statistics()"""
+
+    def test_empty_results(self):
+        """Should return zero counts for empty results"""
+        stats = calculate_statistics([])
+        assert stats[CATEGORY_MATCH] == 0
+        assert stats[CATEGORY_MISMATCH] == 0
+        assert stats[CATEGORY_EXPECTED_NOT_DETECTED] == 0
+        assert stats[CATEGORY_NOT_DEFINED] == 0
+
+    def test_all_match(self):
+        """Should count all as match when all rules match"""
+        results = [
+            {'expected_rule': 'Rule A', 'rule_match': True},
+            {'expected_rule': 'Rule B', 'rule_match': True},
+            {'expected_rule': 'Rule C', 'rule_match': True}
+        ]
+        stats = calculate_statistics(results)
+        assert stats[CATEGORY_MATCH] == 3
+        assert stats[CATEGORY_MISMATCH] == 0
+
+    def test_mixed_statuses(self):
+        """Should correctly count mixed statuses"""
+        results = [
+            {'expected_rule': 'Rule A', 'rule_match': True},  # Match
+            {'expected_rule': 'Rule B', 'rule_match': False},  # Mismatch
+            {'expected_detection': False, 'expected_rule': '', 'rule_match': False},  # Expected Not Detected
+            {'expected_rule': '', 'rule_match': False}  # Not Defined
+        ]
+        stats = calculate_statistics(results)
+        assert stats[CATEGORY_MATCH] == 1
+        assert stats[CATEGORY_MISMATCH] == 1
+        assert stats[CATEGORY_EXPECTED_NOT_DETECTED] == 1
+        assert stats[CATEGORY_NOT_DEFINED] == 1
+
+    def test_realistic_distribution(self):
+        """Test with realistic 100-pattern distribution"""
+        results = []
+        # 95 matches
+        results.extend([{'expected_rule': f'Rule {i}', 'rule_match': True} for i in range(95)])
+        # 0 mismatches
+        # 3 expected not detected
+        results.extend([{'expected_detection': False, 'expected_rule': '', 'rule_match': False} for _ in range(3)])
+        # 2 not defined
+        results.extend([{'expected_rule': '', 'rule_match': False} for _ in range(2)])
+
+        stats = calculate_statistics(results)
+        assert stats[CATEGORY_MATCH] == 95
+        assert stats[CATEGORY_MISMATCH] == 0
+        assert stats[CATEGORY_EXPECTED_NOT_DETECTED] == 3
+        assert stats[CATEGORY_NOT_DEFINED] == 2
+
+
+class TestCreateTrendEntry:
+    """Tests for create_trend_entry()"""
+
+    def test_creates_valid_entry(self):
+        """Should create a valid trend entry"""
+        stats = {
+            CATEGORY_MATCH: 95,
+            CATEGORY_MISMATCH: 0,
+            CATEGORY_EXPECTED_NOT_DETECTED: 3,
+            CATEGORY_NOT_DEFINED: 2
+        }
+        entry = create_trend_entry(
+            run_number=100,
+            report_url='https://example.com/100/',
+            stats=stats
+        )
+
+        assert entry['buildOrder'] == 100
+        assert entry['reportName'] == 'E2E Tests #100'
+        assert entry['reportUrl'] == 'https://example.com/100/'
+        assert entry['data'] == stats
+
+
+class TestMergeTrendHistory:
+    """Tests for merge_trend_history()"""
+
+    def test_empty_history(self):
+        """Should work with empty existing history"""
+        new_entry = {'buildOrder': 100, 'data': {'Match': 95}}
+        result = merge_trend_history(new_entry, [])
+        assert len(result) == 1
+        assert result[0]['buildOrder'] == 100
+
+    def test_adds_to_history(self):
+        """Should add new entry to existing history"""
+        new_entry = {'buildOrder': 102, 'data': {'Match': 97}}
+        existing = [
+            {'buildOrder': 101, 'data': {'Match': 96}},
+            {'buildOrder': 100, 'data': {'Match': 95}}
+        ]
+        result = merge_trend_history(new_entry, existing)
+        assert len(result) == 3
+        assert result[0]['buildOrder'] == 102  # Newest first
+
+    def test_respects_max_history(self):
+        """Should keep only max_history entries"""
+        new_entry = {'buildOrder': 110, 'data': {'Match': 99}}
+        existing = [{'buildOrder': i, 'data': {'Match': i}} for i in range(109, 99, -1)]
+        result = merge_trend_history(new_entry, existing, max_history=5)
+        assert len(result) == 5
+        assert result[0]['buildOrder'] == 110
+        assert result[-1]['buildOrder'] == 106
+
+    def test_deduplicates_by_build_order(self):
+        """Should remove duplicates with same buildOrder"""
+        new_entry = {'buildOrder': 100, 'data': {'Match': 98}}  # Updated
+        existing = [
+            {'buildOrder': 100, 'data': {'Match': 95}},  # Old
+            {'buildOrder': 99, 'data': {'Match': 94}}
+        ]
+        result = merge_trend_history(new_entry, existing)
+        assert len(result) == 2
+        # New entry should be kept (first occurrence wins)
+        assert result[0]['buildOrder'] == 100
+        assert result[0]['data']['Match'] == 98
+
+    def test_sorts_descending(self):
+        """Should sort by buildOrder descending"""
+        new_entry = {'buildOrder': 50, 'data': {}}
+        existing = [
+            {'buildOrder': 100, 'data': {}},
+            {'buildOrder': 75, 'data': {}},
+            {'buildOrder': 25, 'data': {}}
+        ]
+        result = merge_trend_history(new_entry, existing)
+        build_orders = [e['buildOrder'] for e in result]
+        assert build_orders == [100, 75, 50, 25]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Add Rule Mapping Trend graph to Allure Report using Categories Trend feature
- Track Match/Mismatch/Expected Not Detected/Not Defined statistics over time
- Integrate with GitHub Actions Job Summary

## Changes

### New Files
- `e2e/scripts/generate_rule_mapping_trend.py` - Calculate and store Rule Mapping statistics
- `e2e/scripts/test_generate_rule_mapping_trend.py` - Unit tests (17 tests passing)
- `claudedocs/ISSUE_59_TASK_DEFINITION.md` - Task definition document

### Modified Files
- `.github/workflows/e2e-test.yml`
  - Add step 10a: Generate Rule Mapping Trend
  - Add Rule Mapping statistics to Job Summary

## Implementation Approach

Uses Allure's built-in **Categories Trend** feature (same visualization as existing Graphs TREND). This approach was chosen for:
- Consistent visual style with existing Allure trends
- Simpler implementation (no separate dashboard needed)
- Built-in history management via gh-pages

## How It Works

1. After test analysis, `generate_rule_mapping_trend.py` calculates statistics:
   - Rule Match: expected_rule matches detected rule
   - Rule Mismatch: expected_rule differs from detected rule
   - Expected Not Detected: expected_detection=false patterns
   - Not Defined: expected_rule not defined
   
2. Statistics are merged into `categories-trend.json` (last 10 runs)

3. Allure renders the trend in Graphs tab → Categories Trend

## Test Plan

- [x] Unit tests pass (17 tests)
- [x] Local test with sample data
- [ ] E2E workflow run after merge

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)