### PR TITLE
fix(e2e): Remove Issue #59 script causing Categories Trend duplicates

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -702,11 +702,14 @@ jobs:
             echo "Analysis summary not available" >> $GITHUB_STEP_SUMMARY
           fi
 
-          # Issue #59: Add Rule Mapping statistics to summary
+          # Issue #68: Add Rule Mapping statistics to summary
+          # Note: Updated in Issue #70 to read from rule-mapping-trend-history.json
+          #       instead of categories-trend.json (which is managed by Allure CLI)
           echo "" >> $GITHUB_STEP_SUMMARY
-          if [ -f e2e/allure-results/history/categories-trend.json ]; then
-            echo "### Rule Mapping (Issue #59)" >> $GITHUB_STEP_SUMMARY
-            CURRENT_RUN=$(jq -r '.[0]' e2e/allure-results/history/categories-trend.json)
+          if [ -f e2e/allure-results/widgets/rule-mapping-trend-history.json ]; then
+            echo "### Rule Mapping" >> $GITHUB_STEP_SUMMARY
+            # Get the latest entry (sorted by buildOrder ascending, so last is newest)
+            CURRENT_RUN=$(jq -r '.[-1]' e2e/allure-results/widgets/rule-mapping-trend-history.json)
             MATCH=$(echo "$CURRENT_RUN" | jq -r '.data["Rule Match"] // 0')
             MISMATCH=$(echo "$CURRENT_RUN" | jq -r '.data["Rule Mismatch"] // 0')
             EXPECTED_NOT=$(echo "$CURRENT_RUN" | jq -r '.data["Expected Not Detected"] // 0')


### PR DESCRIPTION
## Summary

- Remove Issue #59 script (`generate_rule_mapping_trend.py`) that was causing duplicate entries in Categories Trend graph
- Issue #68's independent HTML solution (`generate_rule_mapping_trend_html.py`) remains as the correct approach

## Problem

E2E Tests #106 showed duplicate entries in Categories Trend:
- X-axis labels: `#89`, `#91`, ..., `#105`, `#106`, `#106` (duplicate!)

## Root Cause

Two processes were writing to the same `categories-trend.json`:

1. **Step 10a**: `generate_rule_mapping_trend.py` (Issue #59)
   - Entry: `{"reportName": "E2E Tests #106", "buildOrder": 106}`

2. **Step 11**: `allure generate` (Allure CLI)
   - Entry: `{"reportName": "Allure Report", "buildOrder": 106}`

## Solution

Remove Issue #59 script call (Step 10a) and keep only Issue #68's solution which:
- Uses its own separate file (`rule-mapping-trend-history.json`)
- Does not conflict with Allure CLI's history management
- Provides an independent HTML visualization

## Test plan

- [ ] E2E test completes successfully
- [ ] Categories Trend shows no duplicate entries
- [ ] Rule Mapping Trend HTML page still works

## Related

- Issue #70: Bug report for this issue
- Issue #59: Original script that caused the conflict
- Issue #68: Correct solution using separate file
- PR #69: HTML page implementation (already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)