### PR TITLE
feat(e2e): Add dedicated Rule Mismatch trend chart

### DIFF
--- a/e2e/scripts/generate_rule_mapping_trend_html.py
+++ b/e2e/scripts/generate_rule_mapping_trend_html.py
@@ -513,6 +513,7 @@ def generate_html(history: List[Dict], current_run: int) -> str:
                         displayColors: true,
                         callbacks: {{
                             title: function(context) {{
+                                if (!context || !context[0]) return '';
                                 const idx = context[0].dataIndex;
                                 return 'Run ' + labels[idx];
                             }}


### PR DESCRIPTION
## Summary

Rule Mapping Trend HTMLページに**Rule Mismatch専用のグラフ**を追加。

Rule Match (327) と Rule Mismatch (21) の差が大きいため、Mismatchの変化が見づらい問題を解決。

## 変更内容

`e2e/scripts/generate_rule_mapping_trend_html.py`:
- Rule Mismatch Trend (Detailed View) チャートを追加
- Rule Mismatch と Expected Not Detected のみを表示
- Y軸を自動スケールで調整（max値の1.2倍）

## 表示イメージ

```
[既存] Rule Mapping Trend (全カテゴリ)
- Rule Match: 327 (大きな緑の線)
- Rule Mismatch: 21 (ほぼ見えない)

[新規] Rule Mismatch Trend (Detailed View)
- Rule Mismatch: 21 (見やすいスケール)
- Expected Not Detected: 2
```

## テスト

次回E2E Test実行後、以下で確認可能:
https://takaosgb3.github.io/falco-plugin-nginx/e2e-report/{run}/widgets/rule-mapping-trend.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)