### PR TITLE
fix: Duplicate entries in Categories Trend (#78)

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -614,8 +614,16 @@ jobs:
             # This is the key fix for Issue #78 - widgets/ is what the charts read from
             echo ""
             echo "Copying merged categories-trend.json to widgets/ for chart rendering..."
-            cp allure-report/history/categories-trend.json allure-report/widgets/categories-trend.json
-            echo "Widgets updated successfully"
+
+            # Ensure widgets directory exists (may not exist if allure generate had issues)
+            mkdir -p allure-report/widgets
+
+            if cp allure-report/history/categories-trend.json allure-report/widgets/categories-trend.json; then
+              echo "Widgets updated successfully"
+            else
+              echo "::error::Failed to copy categories-trend.json to widgets/"
+              echo "This will cause Categories Trend chart to not show Rule Mapping data"
+            fi
           else
             echo "::warning::categories-trend.json does not exist after merge step"
           fi


### PR DESCRIPTION
## Summary
- Fix duplicate entries in Categories Trend caused by PR #77
- Closes #78

## Root Cause

PR #77 moved the merge step to run BEFORE `allure generate`:

```
1. Our script creates entry: "E2E Tests #120"
2. allure generate creates another entry: "Allure Report"
3. Result: Two entries with same buildOrder
```

## Solution

1. Move merge step back to AFTER `allure generate`
2. Merge INTO Allure's entry (not creating new)
3. **Key fix**: Copy merged file to `widgets/` for chart rendering

```
Before (PR #77, broken):
  allure-results/history/ → our script → allure generate → widgets/ (has duplicates)

After (this PR):
  allure generate → allure-report/history/ → our script → copy to widgets/
```

The insight is that charts read from `widgets/`, not `history/`. By updating both:
- `history/` has merged data for future runs (history propagation)
- `widgets/` has merged data for current chart rendering

## Test plan
- [ ] Run E2E test #121+
- [ ] Verify Categories Trend shows single entry per build
- [ ] Verify Rule Mapping data appears in the chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)