### PR TITLE
feat: Phase 8 Stage 3 - GraphQL/XPath/Pickle/LDAP patterns (499→520)

### DIFF
--- a/e2e/k6/main.js
+++ b/e2e/k6/main.js
@@ -303,7 +303,7 @@ export const options = {
     thresholds: {
         'http_req_duration': ['p(95)<5000'],  // 95% of requests under 5s
         'http_req_failed': ['rate<0.05'],      // Less than 5% failure rate
-        'attacks_sent': ['count==499']          // All 499 patterns sent (Phase 8 Stage 2)
+        'attacks_sent': ['count==520']          // All 520 patterns sent (Phase 8 Stage 3)
     },
     summaryTimeUnit: 'ms',
     summaryTrendStats: ['avg', 'med', 'p(90)', 'p(95)', 'p(99)', 'max', 'count']
@@ -493,7 +493,7 @@ export function setup() {
     console.log('========================================');
     console.log('k6 E2E Test Starting (Public Repo Mode)');
     console.log(`Target: ${TARGET_IP}:${TARGET_PORT}`);
-    console.log('Total Patterns: 499 (Phase 8 Stage 2)');
+    console.log('Total Patterns: 520 (Phase 8 Stage 3)');
     console.log('  - SQLi: 124');
     console.log('  - XSS: 81');
     console.log('  - Path: 73');

--- a/e2e/patterns/graphql_patterns.json
+++ b/e2e/patterns/graphql_patterns.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "category": "graphql",
-    "total_patterns": 5,
+    "total_patterns": 10,
     "port": 8008,
     "description": "k6 test patterns for GraphQL injection"
   },
@@ -65,6 +65,71 @@
       "expected_detection": true,
       "expected_rule": "[NGINX SQLi] Boolean-based Blind SQL Injection",
       "severity": "critical"
+    },
+    {
+      "id": "GQL_INTRO_004",
+      "name": "GraphQL __typename introspection query",
+      "category": "graphql",
+      "subcategory": "introspection",
+      "payload": "__typename",
+      "encoded": "__typename",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX GraphQL Attack] Introspection query detected",
+      "severity": "medium",
+      "description": "Simple __typename introspection without nested braces to target GraphQL rule directly"
+    },
+    {
+      "id": "GQL_INTRO_005",
+      "name": "GraphQL URL-encoded __schema introspection",
+      "category": "graphql",
+      "subcategory": "introspection",
+      "payload": "__schema{queryType}",
+      "encoded": "%5F%5Fschema%7BqueryType%7D",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX GraphQL Attack] Introspection query detected",
+      "severity": "medium",
+      "description": "URL-encoded __schema to match encoded introspection condition"
+    },
+    {
+      "id": "GQL_INTRO_006",
+      "name": "GraphQL URL-encoded __typename introspection",
+      "category": "graphql",
+      "subcategory": "introspection",
+      "payload": "__typename",
+      "encoded": "%5F%5Ftypename",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX GraphQL Attack] Introspection query detected",
+      "severity": "medium",
+      "description": "URL-encoded __typename to match encoded introspection condition"
+    },
+    {
+      "id": "GQL_DATA_002",
+      "name": "GraphQL mass extraction via limit keyword",
+      "category": "graphql",
+      "subcategory": "data_extraction",
+      "payload": "limit:999999",
+      "encoded": "limit%3A999999",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX GraphQL Attack] Mass data extraction attempt",
+      "severity": "high",
+      "description": "GraphQL limit parameter with large value for mass data extraction"
+    },
+    {
+      "id": "GQL_DATA_003",
+      "name": "GraphQL mass extraction via first keyword",
+      "category": "graphql",
+      "subcategory": "data_extraction",
+      "payload": "first:999999",
+      "encoded": "first%3A999999",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX GraphQL Attack] Mass data extraction attempt",
+      "severity": "high",
+      "description": "GraphQL first parameter with large value for mass data extraction"
     }
   ]
 }

--- a/e2e/patterns/ldap_patterns.json
+++ b/e2e/patterns/ldap_patterns.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "category": "ldap",
-    "total_patterns": 10,
+    "total_patterns": 15,
     "port": 8006,
     "description": "k6 test patterns for LDAP injection"
   },
@@ -125,6 +125,71 @@
       "expected_detection": true,
       "expected_rule": "[NGINX LDAP Injection] Authentication bypass attempt",
       "severity": "medium"
+    },
+    {
+      "id": "LDAP_ATTR_001",
+      "name": "LDAP Attribute Injection via CN",
+      "category": "ldap",
+      "subcategory": "attribute_injection",
+      "payload": ")(cn=admin",
+      "encoded": ")(cn=admin",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX LDAP Injection] Attribute injection attempt",
+      "severity": "high",
+      "description": "LDAP attribute injection targeting common name field without wildcard prefix"
+    },
+    {
+      "id": "LDAP_ATTR_002",
+      "name": "LDAP Attribute Injection via objectClass",
+      "category": "ldap",
+      "subcategory": "attribute_injection",
+      "payload": ")(objectClass=person",
+      "encoded": ")(objectClass=person",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX LDAP Injection] Attribute injection attempt",
+      "severity": "high",
+      "description": "LDAP objectClass attribute enumeration for person entries"
+    },
+    {
+      "id": "LDAP_ATTR_003",
+      "name": "LDAP Attribute Injection via memberOf",
+      "category": "ldap",
+      "subcategory": "attribute_injection",
+      "payload": ")(memberOf=cn=Users",
+      "encoded": ")(memberOf=cn=Users",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX LDAP Injection] Attribute injection attempt",
+      "severity": "high",
+      "description": "LDAP memberOf attribute injection for group enumeration"
+    },
+    {
+      "id": "LDAP_ATTR_004",
+      "name": "LDAP Attribute Injection via mail",
+      "category": "ldap",
+      "subcategory": "attribute_injection",
+      "payload": ")(mail=admin@target.com",
+      "encoded": ")(mail=admin@target.com",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX LDAP Injection] Attribute injection attempt",
+      "severity": "medium",
+      "description": "LDAP mail attribute injection for email enumeration"
+    },
+    {
+      "id": "LDAP_BLIND_006",
+      "name": "LDAP Blind Injection via cn=Administrators",
+      "category": "ldap",
+      "subcategory": "blind_injection",
+      "payload": "cn=Administrators,ou=Groups",
+      "encoded": "cn=Administrators,ou=Groups",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX LDAP Injection] Blind injection attempt",
+      "severity": "high",
+      "description": "LDAP blind injection targeting Administrators group DN"
     }
   ]
 }

--- a/e2e/patterns/pickle_patterns.json
+++ b/e2e/patterns/pickle_patterns.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "category": "pickle",
-    "total_patterns": 4,
+    "total_patterns": 10,
     "port": 8001,
     "description": "k6 test patterns for Pickle Deserialization attacks"
   },
@@ -53,6 +53,84 @@
       "expected_detection": true,
       "severity": "high",
       "expected_rule": "[NGINX Pickle Attack] Pickle deserialization attack attempt"
+    },
+    {
+      "id": "PICKLE_DESER_005",
+      "name": "__reduce__ Method with Module Context",
+      "category": "pickle",
+      "subcategory": "deserialization",
+      "payload": "module.__reduce__",
+      "encoded": "module.__reduce__",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "critical",
+      "expected_rule": "[NGINX Emerging Threat] Deserialization attack",
+      "description": "Pickle __reduce__ exploitation via module attribute access"
+    },
+    {
+      "id": "PICKLE_DESER_006",
+      "name": "pickle.loads with Request Data",
+      "category": "pickle",
+      "subcategory": "deserialization",
+      "payload": "pickle.loads(request.data)",
+      "encoded": "pickle.loads%28request.data%29",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "critical",
+      "expected_rule": "[NGINX Emerging Threat] Deserialization attack",
+      "description": "Pickle deserialization of untrusted request data"
+    },
+    {
+      "id": "PICKLE_DESER_007",
+      "name": "URL-encoded __reduce__ Exploit",
+      "category": "pickle",
+      "subcategory": "deserialization",
+      "payload": "__reduce__",
+      "encoded": "%5F%5Freduce%5F%5F",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "critical",
+      "expected_rule": "[NGINX Pickle Attack] Pickle deserialization attack attempt",
+      "description": "URL-encoded __reduce__ bypasses general deserialization rule, caught by Pickle-specific rule"
+    },
+    {
+      "id": "PICKLE_DESER_008",
+      "name": "Class MRO Index 2 Traversal",
+      "category": "pickle",
+      "subcategory": "deserialization",
+      "payload": "__class__.__mro__[2].__subclasses__()",
+      "encoded": "__class__.__mro__%5B2%5D.__subclasses__%28%29",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX Pickle Attack] Pickle deserialization attack attempt",
+      "description": "MRO traversal at index 2 for deeper class hierarchy access"
+    },
+    {
+      "id": "PICKLE_DESER_009",
+      "name": "cPickle.loads with Serialized Payload",
+      "category": "pickle",
+      "subcategory": "deserialization",
+      "payload": "cPickle.loads(serialized)",
+      "encoded": "cPickle.loads%28serialized%29",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "critical",
+      "expected_rule": "[NGINX Emerging Threat] Deserialization attack",
+      "description": "cPickle deserialization of serialized payload data"
+    },
+    {
+      "id": "PICKLE_DESER_010",
+      "name": "URL-encoded Class MRO Index 0 Traversal",
+      "category": "pickle",
+      "subcategory": "deserialization",
+      "payload": "__class__.__mro__[0]",
+      "encoded": "%5F%5Fclass%5F%5F.%5F%5Fmro%5F%5F%5B0%5D",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX Pickle Attack] Pickle deserialization attack attempt",
+      "description": "URL-encoded MRO traversal at index 0 for base class access"
     }
   ]
 }

--- a/e2e/patterns/xpath_patterns.json
+++ b/e2e/patterns/xpath_patterns.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "category": "xpath",
-    "total_patterns": 5,
+    "total_patterns": 10,
     "port": 8009,
     "description": "k6 test patterns for XPath injection attacks"
   },
@@ -65,6 +65,71 @@
       "expected_detection": true,
       "severity": "high",
       "expected_rule": "XPath injection attempt"
+    },
+    {
+      "id": "XPATH_AND_001",
+      "name": "XPath AND-based injection with count function",
+      "category": "xpath",
+      "subcategory": "function_abuse",
+      "payload": "' and count(//*) > 0",
+      "encoded": "%27%20and%20count%28%2F%2F*%29%3E0",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX XPath Injection] XPath injection attempt",
+      "description": "XPath AND injection with wildcard count function"
+    },
+    {
+      "id": "XPATH_BOOL_002",
+      "name": "XPath OR-based boolean with true() function",
+      "category": "xpath",
+      "subcategory": "boolean_based",
+      "payload": "' or true() or '",
+      "encoded": "%27%20or%20true%28%29%20or%20%27",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX XPath Injection] XPath injection attempt",
+      "description": "XPath boolean injection using true() function"
+    },
+    {
+      "id": "XPATH_FUNC_002",
+      "name": "XPath substring function name extraction",
+      "category": "xpath",
+      "subcategory": "blind",
+      "payload": "' or substring(//user[1]/name,1,1)='a",
+      "encoded": "%27%20or%20substring%28%2F%2Fuser%5B1%5D%2Fname%2C1%2C1%29%3D%27a",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX XPath Injection] XPath injection attempt",
+      "description": "XPath substring extraction targeting user name field"
+    },
+    {
+      "id": "XPATH_BLIND_002",
+      "name": "XPath string-length blind name enumeration",
+      "category": "xpath",
+      "subcategory": "enumeration",
+      "payload": "' and string-length(//user[1]/name)>3 and '1'='1",
+      "encoded": "%27%20and%20string-length%28%2F%2Fuser%5B1%5D%2Fname%29%3E3%20and%20%271%27%3D%271",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX XPath Injection] XPath injection attempt",
+      "description": "XPath blind injection using string-length on name field"
+    },
+    {
+      "id": "XPATH_PAREN_002",
+      "name": "XPath parenthesis bypass with true() function",
+      "category": "xpath",
+      "subcategory": "authentication_bypass",
+      "payload": "') or true() or ('",
+      "encoded": "%27%29%20or%20true%28%29%20or%20%28%27",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX XPath Injection] XPath injection attempt",
+      "description": "XPath parenthesis bypass using true() for authentication bypass"
     }
   ]
 }

--- a/rules/nginx_rules.yaml
+++ b/rules/nginx_rules.yaml
@@ -696,6 +696,16 @@
         - XPATH_FUNC_001
         - XPATH_BLIND_001
         - XPATH_ENUM_001
+    # Phase 8 Stage 3: New XPath patterns with boolean-like syntax
+    - name: phase8_xpath_boolean_patterns
+      fields: nginx.pattern_id
+      comps: in
+      values:
+        - XPATH_AND_001
+        - XPATH_BOOL_002
+        - XPATH_FUNC_002
+        - XPATH_BLIND_002
+        - XPATH_PAREN_002
     # Issue #43 Fix: Error-based SQLi patterns - should be caught by Error-based SQLi rule
     - name: sqli_error_patterns
       fields: nginx.pattern_id


### PR DESCRIPTION
## Summary
- Add 21 new E2E test patterns across 4 categories (499→520 total)
- GraphQL: +5 patterns (introspection, mass data extraction)
- XPath: +5 patterns (AND/OR injection, function abuse, blind)
- Pickle: +6 patterns (reduce, loads, MRO traversal variants)
- LDAP: +5 patterns (attribute injection, blind injection)
- Add XPath exceptions to Boolean Blind SQLi rule

## Test plan
- [ ] E2E test passes with 520 patterns
- [ ] No rule mismatches
- [ ] All new patterns detected correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)