### PR TITLE
feat(e2e): Phase 9 Stage 2 - Add 20 patterns (542→562)

### DIFF
--- a/e2e/k6/main.js
+++ b/e2e/k6/main.js
@@ -303,7 +303,7 @@ export const options = {
     thresholds: {
         'http_req_duration': ['p(95)<5000'],  // 95% of requests under 5s
         'http_req_failed': ['rate<0.05'],      // Less than 5% failure rate
-        'attacks_sent': ['count==542']          // All 542 patterns sent (Phase 9 Stage 1)
+        'attacks_sent': ['count==562']          // All 562 patterns sent (Phase 9 Stage 2)
     },
     summaryTimeUnit: 'ms',
     summaryTrendStats: ['avg', 'med', 'p(90)', 'p(95)', 'p(99)', 'max', 'count']
@@ -493,7 +493,7 @@ export function setup() {
     console.log('========================================');
     console.log('k6 E2E Test Starting (Public Repo Mode)');
     console.log(`Target: ${TARGET_IP}:${TARGET_PORT}`);
-    console.log('Total Patterns: 542 (Phase 9 Stage 1)');
+    console.log('Total Patterns: 562 (Phase 9 Stage 2)');
     console.log('  - SQLi: 124');
     console.log('  - XSS: 81');
     console.log('  - Path: 73');

--- a/e2e/patterns/graphql_patterns.json
+++ b/e2e/patterns/graphql_patterns.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "category": "graphql",
-    "total_patterns": 10,
+    "total_patterns": 15,
     "port": 8008,
     "description": "k6 test patterns for GraphQL injection"
   },
@@ -130,6 +130,71 @@
       "expected_rule": "[NGINX GraphQL Attack] Mass data extraction attempt",
       "severity": "high",
       "description": "GraphQL first parameter with large value for mass data extraction"
+    },
+    {
+      "id": "GQL_INTRO_007",
+      "name": "GraphQL URL-encoded __type introspection",
+      "category": "graphql",
+      "subcategory": "introspection",
+      "payload": "__type(name:\"Query\")",
+      "encoded": "%5F%5Ftype(name%3A%22Query%22)",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX GraphQL Attack] Introspection query detected",
+      "severity": "medium",
+      "description": "URL-encoded __type to independently test %5F%5Ftype condition"
+    },
+    {
+      "id": "GQL_INTRO_008",
+      "name": "GraphQL raw __schema introspection",
+      "category": "graphql",
+      "subcategory": "introspection",
+      "payload": "__schema",
+      "encoded": "__schema",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX GraphQL Attack] Introspection query detected",
+      "severity": "medium",
+      "description": "Raw __schema keyword to test non-encoded introspection condition on port 80"
+    },
+    {
+      "id": "GQL_DATA_004",
+      "name": "GraphQL encoded users with password extraction",
+      "category": "graphql",
+      "subcategory": "data_extraction",
+      "payload": "{users(first:10){id,password}}",
+      "encoded": "%7Busers(first%3A10)%7Bid%2Cpassword%7D",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX GraphQL Attack] Mass data extraction attempt",
+      "severity": "high",
+      "description": "Tests %7Busers + password condition for mass data extraction"
+    },
+    {
+      "id": "GQL_DATA_005",
+      "name": "GraphQL raw first keyword mass extraction",
+      "category": "graphql",
+      "subcategory": "data_extraction",
+      "payload": "first:9999",
+      "encoded": "first:9999",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX GraphQL Attack] Mass data extraction attempt",
+      "severity": "high",
+      "description": "Raw first: with colon to test icontains 'first:' condition path (not first%3A)"
+    },
+    {
+      "id": "GQL_DATA_006",
+      "name": "GraphQL raw limit keyword mass extraction",
+      "category": "graphql",
+      "subcategory": "data_extraction",
+      "payload": "limit:9999",
+      "encoded": "limit:9999",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX GraphQL Attack] Mass data extraction attempt",
+      "severity": "high",
+      "description": "Raw limit: with colon to test icontains 'limit:' condition path (not limit%3A)"
     }
   ]
 }

--- a/e2e/patterns/http_smuggling_patterns.json
+++ b/e2e/patterns/http_smuggling_patterns.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "category": "http_smuggling",
-    "total_patterns": 10,
+    "total_patterns": 15,
     "port": 8015,
     "description": "k6 test patterns for HTTP Request Smuggling attacks (Phase 7)"
   },
@@ -135,6 +135,71 @@
       "severity": "high",
       "expected_rule": "[NGINX HRS] HTTP Request Smuggling attempt",
       "description": "Double URL-encoded Transfer-Encoding header"
+    },
+    {
+      "id": "HRS_ENCLEN_001",
+      "name": "Encoded Hyphen Content-Length",
+      "category": "http_smuggling",
+      "subcategory": "obfuscation",
+      "payload": "Content-Length: 0",
+      "encoded": "Content%2DLength%3A%200",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX HRS] HTTP Request Smuggling attempt",
+      "description": "Content-Length with encoded hyphen (%2D) to test Content%2DLength condition"
+    },
+    {
+      "id": "HRS_ENCHOST_001",
+      "name": "Encoded Hyphen X-Forwarded-Host",
+      "category": "http_smuggling",
+      "subcategory": "obfuscation",
+      "payload": "X-Forwarded-Host: evil.com",
+      "encoded": "X%2DForwarded%2DHost%3A%20evil.com",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX HRS] HTTP Request Smuggling attempt",
+      "description": "X-Forwarded-Host with encoded hyphens (%2D) to test X%2DForwarded%2DHost condition"
+    },
+    {
+      "id": "HRS_RAWCL_001",
+      "name": "Raw Content-Length Header",
+      "category": "http_smuggling",
+      "subcategory": "header_injection",
+      "payload": "Content-Length:0",
+      "encoded": "Content-Length:0",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX HRS] HTTP Request Smuggling attempt",
+      "description": "Raw Content-Length: with unencoded colon to test icontains 'Content-Length:' condition"
+    },
+    {
+      "id": "HRS_ENCTE_001",
+      "name": "Single Encoded Transfer-Encoding",
+      "category": "http_smuggling",
+      "subcategory": "obfuscation",
+      "payload": "Transfer-Encoding: chunked",
+      "encoded": "Transfer%2DEncoding%3A%20chunked",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX HRS] HTTP Request Smuggling attempt",
+      "description": "Transfer-Encoding with single-encoded hyphen to test Transfer%2DEncoding condition"
+    },
+    {
+      "id": "HRS_LOWCASE_001",
+      "name": "Lowercase Transfer-Encoding",
+      "category": "http_smuggling",
+      "subcategory": "obfuscation",
+      "payload": "transfer-encoding:chunked",
+      "encoded": "transfer-encoding:chunked",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX HRS] HTTP Request Smuggling attempt",
+      "description": "Lowercase transfer-encoding to test icontains case-insensitive matching"
     }
   ]
 }

--- a/e2e/patterns/other_patterns.json
+++ b/e2e/patterns/other_patterns.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "category": "other",
-    "total_patterns": 10,
+    "total_patterns": 15,
     "port": 8005,
     "description": "k6 test patterns for other"
   },
@@ -125,6 +125,71 @@
       "expected_detection": true,
       "expected_rule": "[NGINX Emerging Threat] Deserialization attack",
       "severity": "critical"
+    },
+    {
+      "id": "EMRG_MONGO_006",
+      "name": "MongoDB less-than operator injection",
+      "category": "other",
+      "subcategory": "mongodb_injection",
+      "payload": "{\"$lt\": 10}",
+      "encoded": "%7B%22%24lt%22%3A%2010%7D",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX Emerging Threat] MongoDB NoSQL injection",
+      "severity": "high",
+      "description": "MongoDB $lt operator to test previously uncovered %24lt condition"
+    },
+    {
+      "id": "EMRG_MONGO_007",
+      "name": "CouchDB _all_docs enumeration",
+      "category": "other",
+      "subcategory": "mongodb_injection",
+      "payload": "_all_docs",
+      "encoded": "_all_docs",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX Emerging Threat] MongoDB NoSQL injection",
+      "severity": "high",
+      "description": "CouchDB _all_docs endpoint access to test icontains '_all_docs' condition"
+    },
+    {
+      "id": "EMRG_MONGO_008",
+      "name": "MongoDB $exists operator bypass",
+      "category": "other",
+      "subcategory": "mongodb_injection",
+      "payload": "{\"$exists\": true}",
+      "encoded": "%7B%22%24exists%22%3A%20true%7D",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX Emerging Threat] MongoDB NoSQL injection",
+      "severity": "high",
+      "description": "MongoDB $exists operator to test previously uncovered %24exists condition"
+    },
+    {
+      "id": "OTHER_REDIS_002",
+      "name": "Redis database flush specific DB",
+      "category": "other",
+      "subcategory": "redis_injection",
+      "payload": "FLUSHDB",
+      "encoded": "FLUSHDB",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX Emerging Threat] Redis command injection",
+      "severity": "critical",
+      "description": "Redis FLUSHDB command to test previously uncovered FLUSHDB condition"
+    },
+    {
+      "id": "OTHER_REDIS_003",
+      "name": "Redis CONFIG SET password override",
+      "category": "other",
+      "subcategory": "redis_injection",
+      "payload": "CONFIG SET requirepass hacked",
+      "encoded": "CONFIG%20SET%20requirepass%20hacked",
+      "port": 80,
+      "expected_detection": true,
+      "expected_rule": "[NGINX Emerging Threat] Redis command injection",
+      "severity": "critical",
+      "description": "Redis CONFIG SET to test previously uncovered CONFIG%20SET condition"
     }
   ]
 }

--- a/e2e/patterns/pickle_patterns.json
+++ b/e2e/patterns/pickle_patterns.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "category": "pickle",
-    "total_patterns": 10,
+    "total_patterns": 15,
     "port": 8001,
     "description": "k6 test patterns for Pickle Deserialization attacks"
   },
@@ -131,6 +131,71 @@
       "severity": "high",
       "expected_rule": "[NGINX Pickle Attack] Pickle deserialization attack attempt",
       "description": "URL-encoded MRO traversal at index 0 for base class access"
+    },
+    {
+      "id": "PICKLE_DESER_011",
+      "name": "Uppercase __REDUCE__ Case Bypass",
+      "category": "pickle",
+      "subcategory": "deserialization",
+      "payload": "__REDUCE__",
+      "encoded": "__REDUCE__",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "critical",
+      "expected_rule": "[NGINX Pickle Attack] Pickle deserialization attack attempt",
+      "description": "Uppercase __REDUCE__ bypasses Deserialization rule (case-sensitive contains) but caught by Pickle rule (icontains)"
+    },
+    {
+      "id": "PICKLE_DESER_012",
+      "name": "URL-encoded MRO Index 3 Traversal",
+      "category": "pickle",
+      "subcategory": "deserialization",
+      "payload": "__class__.__mro__[3]",
+      "encoded": "%5F%5Fclass%5F%5F.%5F%5Fmro%5F%5F%5B3%5D",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX Pickle Attack] Pickle deserialization attack attempt",
+      "description": "URL-encoded MRO traversal at index 3 to test %5F%5Fclass%5F%5F.%5F%5Fmro%5F%5F condition"
+    },
+    {
+      "id": "PICKLE_DESER_013",
+      "name": "MRO __getitem__ Method Access",
+      "category": "pickle",
+      "subcategory": "deserialization",
+      "payload": "__class__.__mro__.__getitem__(0)",
+      "encoded": "__class__.__mro__.__getitem__%280%29",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "high",
+      "expected_rule": "[NGINX Pickle Attack] Pickle deserialization attack attempt",
+      "description": "Alternative MRO access via __getitem__ method to test __class__.__mro__ condition"
+    },
+    {
+      "id": "PICKLE_DESER_014",
+      "name": "YAML Unsafe Load Deserialization",
+      "category": "pickle",
+      "subcategory": "deserialization",
+      "payload": "yaml.load(data)",
+      "encoded": "yaml.load%28data%29",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "critical",
+      "expected_rule": "[NGINX Emerging Threat] Deserialization attack",
+      "description": "YAML unsafe load deserialization to test yaml.load condition in Deserialization rule"
+    },
+    {
+      "id": "PICKLE_DESER_015",
+      "name": "Python YAML Object Instantiation",
+      "category": "pickle",
+      "subcategory": "deserialization",
+      "payload": "!!python/object:os.system",
+      "encoded": "!!python/object:os.system",
+      "port": 80,
+      "expected_detection": true,
+      "severity": "critical",
+      "expected_rule": "[NGINX Emerging Threat] Deserialization attack",
+      "description": "Python YAML !!python tag for arbitrary object instantiation to test !!python condition"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds 20 new E2E test patterns across GraphQL (+5), HTTP Smuggling (+5), Pickle (+5), Other (+5)
- Total patterns: 542 → 562
- Zero cross-rule exceptions needed

Replaces closed PR #88 (base branch changed to main after Stage 1 merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)